### PR TITLE
StorageMechanisms usable outside of React + deep memo

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "watch": "yarn lerna run watch --parallel"
   },
   "dependencies": {
-    "deep-memo": "^0.1.0",
     "lerna": "^3.10.7"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "watch": "yarn lerna run watch --parallel"
   },
   "dependencies": {
+    "deep-memo": "^0.1.0",
     "lerna": "^3.10.7"
   },
   "devDependencies": {

--- a/packages/react-cool-storage-docs/src/example/MemoryStorageExample.jsx
+++ b/packages/react-cool-storage-docs/src/example/MemoryStorageExample.jsx
@@ -23,7 +23,16 @@ const MemoryStorageExample = (props) => {
     </div>;
 };
 
+const MyMemoryStorage = MemoryStorage();
+
 export default ReactCoolStorageHoc(
     'memoryStorage',
-    MemoryStorage()
+    MyMemoryStorage
 )(MemoryStorageExample);
+
+// also add this MemoryStorage instance to the window
+// to demonstrate usage outside of React
+
+if(typeof window !== "undefined") {
+    window.MyMemoryStorage = MyMemoryStorage;
+}

--- a/packages/react-cool-storage-docs/src/example/WebStorageExample.jsx
+++ b/packages/react-cool-storage-docs/src/example/WebStorageExample.jsx
@@ -29,3 +29,12 @@ export default ReactCoolStorageHoc(
         key: 'exampleStorage'
     })
 )(WebStorageExample);
+
+// also add a WebStorage instance to the window
+// to demonstrate usage outside of React
+
+if(typeof window !== "undefined") {
+    window.MyWebStorage = WebStorage({
+        key: 'exampleStorage'
+    });
+}

--- a/packages/react-cool-storage-docs/src/pages/api/MemoryStorage.mdx
+++ b/packages/react-cool-storage-docs/src/pages/api/MemoryStorage.mdx
@@ -7,7 +7,7 @@ import MemoryStorageExample from '../../example/MemoryStorageExample';
 
 MemoryStorage gives you an easy to use binding for working with data stored in memory. Often this is used as a fallback storage mechanism when others are unavailable.
 
-Each instanciation of `MemoryStorage()` contains it's own unique data store. You can use the one MemoryStorage instance in many ReactCoolStorageHocs and they will all remain in sync with each other.
+Each instanciation of `MemoryStorage()` contains its own unique data store. You can use the one MemoryStorage instance in many ReactCoolStorageHocs and they will all remain in sync with each other.
 
 There are no limitations on the kind of data it can store.
 
@@ -28,6 +28,12 @@ MemoryStorage requires no resources.
 ## Props
 
 MemoryStorage requires no props.
+
+## Outside React
+
+MemoryStorage doesn't require any props, so you can also access and change a MemoryStorage instance's value outside of React. All ReactCoolStorageHocs that use the MemoryStorage will update and stay in sync.
+
+A `MyMemoryStorage` instance has been added to the window. Try running `MyMemoryStorage.onChange({foo: "foo"});` in the console and watch the example update at the top of this page.
 
 ## Example
 
@@ -56,9 +62,18 @@ const MemoryStorageExample = (props) => {
     </div>;
 };
 
+const MyMemoryStorage = MemoryStorage();
+
 export default ReactCoolStorageHoc(
     'memoryStorage',
-    MemoryStorage()
+    MyMemoryStorage
 )(MemoryStorageExample);
+
+// also add this MemoryStorage instance to the window
+// to demonstrate usage outside of React
+
+if(typeof window !== "undefined") {
+    window.MyMemoryStorage = MyMemoryStorage;
+}
 
 `}</Code>

--- a/packages/react-cool-storage-docs/src/pages/api/ReachRouterQueryString.mdx
+++ b/packages/react-cool-storage-docs/src/pages/api/ReachRouterQueryString.mdx
@@ -15,7 +15,7 @@ It is **controlled**, meaning that it will update immediately whenever the data 
 <Code language="jsx">{`
 import ReachRouterQueryString from 'react-cool-storage/ReachRouterQueryString';
 
-ReactCoolStorageHoc({
+ReachRouterQueryString({
     navigate: Function,
     // optional
     method?: string = "push",

--- a/packages/react-cool-storage-docs/src/pages/api/ReachRouterQueryString.mdx
+++ b/packages/react-cool-storage-docs/src/pages/api/ReachRouterQueryString.mdx
@@ -22,7 +22,8 @@ ReachRouterQueryString({
     deconstruct?: (data: any) => any, // convert to serializable data
     reconstruct?: (data: any) => any, // convert from serializable data
     parse?: (data: string) => any,
-    stringify?: (data: any) => string
+    stringify?: (data: any) => string,
+    memoize?: boolean = true
 })`}</Code>
 
 - `navigate` - The `navigate` method exported from Reach Router. e.g. `import {navigate} from "@reach/router"`
@@ -31,6 +32,7 @@ ReachRouterQueryString({
 - `reconstruct` - Used to convert data from a serializable format into richer data types. It is called after ReachRouterQueryString has parsed its data. It is given the parsed object. Defaults to a passthrough function.
 - `parse` - A function that is called on the value of each key / value pair to turn it from a string into a data shape. Defaults to `JSON.parse()`.
 - `stringify` - A function that is called on the value of each key / value pair to turn it from a data shape into a string. Defaults to `JSON.stringify()`.
+- `memoize` - When true, the result of `parse` will be memoized deeply using [deep-memo](https://www.npmjs.com/package/deep-memo) so that references to objects and arrays will remain unchanged unless their values change. This allows parts of the `value` data object to work seamlessly with React pure components. When false, new objects and arrays will be created every time props change, but if a large amount of data is being parsed then disabling memoization can reduce the computation time of the parsing step. Defaults to true.
 
 ## Resources
 

--- a/packages/react-cool-storage-docs/src/pages/api/ReactRouterQueryString.mdx
+++ b/packages/react-cool-storage-docs/src/pages/api/ReactRouterQueryString.mdx
@@ -22,7 +22,8 @@ ReactRouterQueryString({
     deconstruct?: (data: any) => any,
     reconstruct?: (data: any) => any,
     parse?: (data: string) => any,
-    stringify?: (data: any) => string
+    stringify?: (data: any) => string,
+    memoize?: boolean = true
 })`}</Code>
 
 - `method` - The `history` method to use. Can be "push" or "replace". Defaults to "push".
@@ -30,6 +31,7 @@ ReactRouterQueryString({
 - `reconstruct` - Used to convert data from a serializable format into richer data types. It is called after ReactRouterQueryString has parsed its data. It is given the parsed object. Defaults to a passthrough function.- `parse` - A function that is called on the value of each key / value pair to turn it from a string into a data shape. Defaults to `JSON.parse()`.
 - `parse` - A function that is called on the value of each key / value pair to turn it from a string into a data shape. Defaults to `JSON.parse()`.
 - `stringify` - A function that is called on the value of each key / value pair to turn it from a data shape into a string. Defaults to `JSON.stringify()`.
+- `memoize` - When true, the result of `parse` will be memoized deeply using [deep-memo](https://www.npmjs.com/package/deep-memo) so that references to objects and arrays will remain unchanged unless their values change. This allows parts of the `value` data object to work seamlessly with React pure components. When false, new objects and arrays will be created every time props change, but if a large amount of data is being parsed then disabling memoization can reduce the computation time of the parsing step. Defaults to true.
 
 ## Resources
 

--- a/packages/react-cool-storage-docs/src/pages/api/ReactRouterQueryString.mdx
+++ b/packages/react-cool-storage-docs/src/pages/api/ReactRouterQueryString.mdx
@@ -16,7 +16,7 @@ It is **controlled**, meaning that it will update immediately whenever the data 
 <Code language="jsx">{`
 import ReactRouterQueryString from 'react-cool-storage/ReactRouterQueryString';
 
-ReactCoolStorageHoc({
+ReactRouterQueryString({
     // optional
     method?: string = "push",
     deconstruct?: (data: any) => any,

--- a/packages/react-cool-storage-docs/src/pages/api/WebStorage.mdx
+++ b/packages/react-cool-storage-docs/src/pages/api/WebStorage.mdx
@@ -43,6 +43,13 @@ This generally means that the browser must support web storage, allow its use, a
 ## Props
 WebStorage requires no props.
 
+## Outside React
+
+WebStorage doesn't require any props, so you can also access and change WebStorage data outside of React. All ReactCoolStorageHocs that use the WebStorage with the same key will update and stay in sync.
+
+`MyWebStorage` has been added to the window. Try running `MyWebStorage.onChange({foo: "foo"});` in the console and watch the example update at the top of this page.
+
+
 ## Example
 
 <Code language="jsx">{`
@@ -76,4 +83,15 @@ export default ReactCoolStorageHoc(
         key: 'exampleStorage'
     })
 )(WebStorageExample);
+
+// also add a WebStorage instance to the window
+// to demonstrate usage outside of React
+
+if(typeof window !== "undefined") {
+    window.MyWebStorage = WebStorage({
+        key: 'exampleStorage'
+    });
+}
+
+
 `}</Code>

--- a/packages/react-cool-storage-docs/src/pages/api/WebStorage.mdx
+++ b/packages/react-cool-storage-docs/src/pages/api/WebStorage.mdx
@@ -24,7 +24,8 @@ WebStorage({
     deconstruct?: (data: any) => any,
     reconstruct?: (data: any) => any,
     parse?: (data: string) => any,
-    stringify?: (data: any) => string
+    stringify?: (data: any) => string,
+    memoize?: boolean = true
 })
 `}</Code>
 
@@ -34,6 +35,7 @@ WebStorage({
 - `reconstruct` - Used to convert data from a serializable format into richer data types. It is called after WebStorage has parsed its data. It is given the parsed object. Defaults to a passthrough function.- `parse` - A function that is called on the value of each key / value pair to turn it from a string into a data shape. Defaults to `JSON.parse()`.
 - `parse` - A function that is called on the value of each key / value pair to turn it from a string into a data shape. Defaults to `JSON.parse()`.
 - `stringify` - A function that is called on the value of each key / value pair to turn it from a data shape into a string. Defaults to `JSON.stringify()`.
+- `memoize` - When true, the result of `parse` will be memoized deeply using [deep-memo](https://www.npmjs.com/package/deep-memo) so that references to objects and arrays will remain unchanged unless their values change. This allows parts of the `value` data object to work seamlessly with React pure components. When false, new objects and arrays will be created every time ReactCoolStorage's web storage data changes, but if a large amount of data is being parsed then disabling memoization can reduce the computation time of the parsing step. Defaults to true.
 
 ## Resources
 WebStorage requires `window.localStorage` or `window.sessionStorage` to be available, depending on the `method` you choose.

--- a/packages/react-cool-storage/InvalidValueMarker.js
+++ b/packages/react-cool-storage/InvalidValueMarker.js
@@ -1,0 +1,2 @@
+/* eslint-disable */
+module.exports = require('./lib/InvalidValueMarker.js');

--- a/packages/react-cool-storage/package.json
+++ b/packages/react-cool-storage/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@babel/runtime": "^7.1.5",
     "storage-available": "^1.1.0",
-    "unmutable": "^0.43.0"
+    "unmutable": "^0.44.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.2",

--- a/packages/react-cool-storage/package.json
+++ b/packages/react-cool-storage/package.json
@@ -35,8 +35,9 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.5",
+    "deep-memo": "^0.1.2",
     "storage-available": "^1.1.0",
-    "unmutable": "^0.44.0"
+    "unmutable": "^0.45.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.2",

--- a/packages/react-cool-storage/package.json
+++ b/packages/react-cool-storage/package.json
@@ -11,6 +11,7 @@
   },
   "files": [
     "lib",
+    "InvalidValueMarker.js",
     "MemoryStorage.js",
     "ReactCoolStorageMessage.js",
     "ReachRouterQueryString.js",

--- a/packages/react-cool-storage/src/InvalidValueMarker.js
+++ b/packages/react-cool-storage/src/InvalidValueMarker.js
@@ -1,0 +1,4 @@
+// @flow
+
+const INVALID_VALUE_MARKER = Symbol('INVALID_VALUE_MARKER');
+export default INVALID_VALUE_MARKER;

--- a/packages/react-cool-storage/src/MemoryStorage.js
+++ b/packages/react-cool-storage/src/MemoryStorage.js
@@ -54,4 +54,4 @@ class MemoryStorage extends StorageMechanism {
     }
 }
 
-export default (config: ?Config): StorageMechanism => new MemoryStorage(config);
+export default (config: ?Config): StorageMechanism => new MemoryStorage(config || {});

--- a/packages/react-cool-storage/src/MemoryStorage.js
+++ b/packages/react-cool-storage/src/MemoryStorage.js
@@ -54,4 +54,4 @@ class MemoryStorage extends StorageMechanism {
     }
 }
 
-export default (config: Config): StorageMechanism => new MemoryStorage(config);
+export default (config: ?Config): StorageMechanism => new MemoryStorage(config);

--- a/packages/react-cool-storage/src/MemoryStorage.js
+++ b/packages/react-cool-storage/src/MemoryStorage.js
@@ -2,30 +2,56 @@
 import StorageMechanism from './StorageMechanism';
 import Synchronizer from './Synchronizer';
 
-const storageType = 'MemoryStorage';
+import isKeyed from 'unmutable/lib/isKeyed';
 
-export default (): StorageMechanism => {
-
-    let valueStore = {};
-
-    let getValue = () => valueStore;
-
-    let checkAvailable = () => {}; // always available
-
-    let synchronizer = new Synchronizer(); // create one synchronizer per MemoryStorage instance
-
-    let storageMechanism = new StorageMechanism({
-        checkAvailable,
-        getValue,
-        storageType,
-        synchronizer,
-        updateFromProps: false
-    });
-
-    storageMechanism.handleChange = ({updatedValue, origin}: *) => {
-        valueStore = updatedValue;
-        synchronizer.onSync(valueStore, origin);
-    };
-
-    return storageMechanism;
+type Config = {
+    initialValue?: any
 };
+
+class MemoryStorage extends StorageMechanism {
+
+    constructor(config: Config = {}) {
+        let {initialValue} = config;
+
+        let type = 'MemoryStorage';
+
+        super({
+            requiresProps: false,
+            synchronizer: new Synchronizer(),
+            type,
+            updateFromProps: false
+        });
+
+        if(initialValue && !isKeyed(initialValue)) {
+            throw new Error(`${type} initialValue must be passed an object`);
+        }
+
+        this._valueStore = config.initialValue || {};
+    }
+
+    //
+    // private
+    //
+
+    _valueStore: any;
+
+    //
+    // private overrides
+    //
+
+    _availableFromProps(props: any /* eslint-disable-line */): ?string {
+        // always available
+        return undefined;
+    }
+
+    _valueFromProps(props: any /* eslint-disable-line */): any {
+        return this._valueStore;
+    }
+
+    _handleChange({updatedValue, origin}: any): void {
+        this._valueStore = updatedValue;
+        this._synchronizer && this._synchronizer.onSync(this._valueStore, origin);
+    }
+}
+
+export default (config: Config): StorageMechanism => new MemoryStorage(config);

--- a/packages/react-cool-storage/src/ReachRouterQueryString.js
+++ b/packages/react-cool-storage/src/ReachRouterQueryString.js
@@ -11,7 +11,8 @@ type Config = {
     parse?: (data: string) => any,
     stringify?: (data: any) => string,
     deconstruct?: Function,
-    reconstruct?: Function
+    reconstruct?: Function,
+    memoize?: boolean
 };
 
 type Props = {
@@ -30,7 +31,8 @@ class ReachRouterQueryString extends StorageMechanism {
             parse = (data: string): any => JSON.parse(data),
             stringify = (data: any): string => JSON.stringify(data),
             deconstruct,
-            reconstruct
+            reconstruct,
+            memoize = true
         } = config;
 
         const type = 'ReachRouterQueryString';
@@ -53,14 +55,18 @@ class ReachRouterQueryString extends StorageMechanism {
 
         this._navigate = navigate;
         this._method = method;
-        this._parse = deepMemo((str) => {
+        this._parse = (str) => {
             try {
                 return parse(str);
             } catch(e) {
                 return InvalidValueMarker;
             }
-        });
+        };
         this._stringify = stringify;
+
+        if(memoize) {
+            this._parse = deepMemo(this._parse);
+        }
     }
 
     //

--- a/packages/react-cool-storage/src/ReachRouterQueryString.js
+++ b/packages/react-cool-storage/src/ReachRouterQueryString.js
@@ -2,6 +2,7 @@
 import forEach from 'unmutable/forEach';
 import pipeWith from 'unmutable/pipeWith';
 import StorageMechanism from './StorageMechanism';
+import deepMemo from 'deep-memo';
 
 type Config = {
     navigate: Function,
@@ -51,7 +52,7 @@ class ReachRouterQueryString extends StorageMechanism {
 
         this._navigate = navigate;
         this._method = method;
-        this._parse = parse;
+        this._parse = deepMemo(parse);
         this._stringify = stringify;
     }
 
@@ -80,12 +81,18 @@ class ReachRouterQueryString extends StorageMechanism {
     }
 
     _valueFromProps(props: Props /* eslint-disable-line */): any {
-        let query = {};
         let searchParams = this._getSearchParams(props);
-        for (let [key, value] of searchParams) {
-            query[key] = this._parse(value);
+
+        let params = [];
+        for (let searchParam of searchParams) {
+            params.push(searchParam);
         }
-        return query;
+
+        let json = params
+            .map(([key, value]) => `"${key}": ${value}`)
+            .join(",");
+
+        return this._parse(`{${json}}`);
     }
 
     _handleChange({changedValues, removedKeys, props}: any): void {

--- a/packages/react-cool-storage/src/ReachRouterQueryString.js
+++ b/packages/react-cool-storage/src/ReachRouterQueryString.js
@@ -1,6 +1,7 @@
 // @flow
 import forEach from 'unmutable/forEach';
 import pipeWith from 'unmutable/pipeWith';
+import InvalidValueMarker from './InvalidValueMarker';
 import StorageMechanism from './StorageMechanism';
 import deepMemo from 'deep-memo';
 
@@ -52,7 +53,13 @@ class ReachRouterQueryString extends StorageMechanism {
 
         this._navigate = navigate;
         this._method = method;
-        this._parse = deepMemo(parse);
+        this._parse = deepMemo((str) => {
+            try {
+                return parse(str);
+            } catch(e) {
+                return InvalidValueMarker;
+            }
+        });
         this._stringify = stringify;
     }
 

--- a/packages/react-cool-storage/src/ReactRouterQueryString.js
+++ b/packages/react-cool-storage/src/ReactRouterQueryString.js
@@ -1,10 +1,10 @@
 // @flow
-import pipeWith from 'unmutable/pipeWith';
 import forEach from 'unmutable/forEach';
+import pipeWith from 'unmutable/pipeWith';
 import StorageMechanism from './StorageMechanism';
 
 type Config = {
-    method?: "push"|"replace",
+    method?: "localStorage"|"sessionStorage",
     parse?: (data: string) => any,
     stringify?: (data: any) => string,
     deconstruct?: Function,
@@ -21,49 +21,76 @@ type Props = {
     }
 };
 
-const storageType = 'ReactRouterQueryString';
+class ReactRouterQueryString extends StorageMechanism {
 
-export default (config: Config = {}): StorageMechanism => {
-    let {
-        method = "push",
-        parse = (data: string): any => JSON.parse(data),
-        stringify = (data: any): string => JSON.stringify(data),
-        deconstruct,
-        reconstruct
-    } = config;
+    constructor(config: Config = {}) {
+        let {
+            method = "push",
+            parse = (data: string): any => JSON.parse(data),
+            stringify = (data: any): string => JSON.stringify(data),
+            deconstruct,
+            reconstruct
+        } = config;
 
-    if(method !== "push" && method !== "replace") {
-        throw new Error(`${storageType} expects param "config.method" to be either "push" or "replace"`);
+        const type = 'ReactRouterQueryString';
+
+        if(method !== "push" && method !== "replace") {
+            throw new Error(`${type} expects param "config.method" to be either "push" or "replace"`);
+        }
+
+        super({
+            deconstruct,
+            reconstruct,
+            requiresProps: true,
+            type,
+            updateFromProps: true
+        });
+
+        this._method = method;
+        this._parse = parse;
+        this._stringify = stringify;
     }
 
-    let getSearchParams = (props: any) => new window.URLSearchParams(props.location.search);
+    //
+    // private
+    //
 
-    let getValue = (props: Props): any => {
-        let query = {};
-        let searchParams = getSearchParams(props);
-        for (let [key, value] of searchParams) {
-            query[key] = parse(value);
-        }
-        return query;
-    };
+    _navigate: Function;
+    _method: "push"|"replace";
+    _parse: (data: string) => any;
+    _stringify: (data: any) => string;
+    _getSearchParams = (props: Props) => new window.URLSearchParams(props.location.search);
 
-    let checkAvailable = (props: Props): ?string => {
+    //
+    // private overrides
+    //
+
+    _availableFromProps(props: Props /* eslint-disable-line */): ?string {
         if(typeof window === "undefined" || typeof window.URLSearchParams === "undefined") {
-            return `${storageType} requires URLSearchParams to be defined`;
+            return `${this._type} requires URLSearchParams to be defined`;
         }
 
         if(!props.history || !props.location) {
-            return `${storageType} requires React Router history and location props`;
+            return `${this._type} requires React Router history and location props`;
         }
-    };
+    }
 
-    let handleChange = ({changedValues, removedKeys, props}: *) => {
-        let searchParams = getSearchParams(props);
+    _valueFromProps(props: Props /* eslint-disable-line */): any {
+        let query = {};
+        let searchParams = this._getSearchParams(props);
+        for (let [key, value] of searchParams) {
+            query[key] = this._parse(value);
+        }
+        return query;
+    }
+
+    _handleChange({changedValues, removedKeys, props}: any): void {
+        let searchParams = this._getSearchParams(props);
 
         pipeWith(
             changedValues,
             forEach((value, key) => {
-                searchParams.set(key, stringify(value));
+                searchParams.set(key, this._stringify(value));
             })
         );
 
@@ -74,16 +101,9 @@ export default (config: Config = {}): StorageMechanism => {
             })
         );
 
-        props.history[method]("?" + searchParams.toString());
-    };
+        props.history[this._method]("?" + searchParams.toString());
+    }
+}
 
-    return new StorageMechanism({
-        checkAvailable,
-        getValue,
-        handleChange,
-        storageType,
-        deconstruct,
-        reconstruct,
-        updateFromProps: true
-    });
-};
+export default (config: Config): StorageMechanism => new ReactRouterQueryString(config);
+

--- a/packages/react-cool-storage/src/ReactRouterQueryString.js
+++ b/packages/react-cool-storage/src/ReactRouterQueryString.js
@@ -10,7 +10,8 @@ type Config = {
     parse?: (data: string) => any,
     stringify?: (data: any) => string,
     deconstruct?: Function,
-    reconstruct?: Function
+    reconstruct?: Function,
+    memoize?: boolean
 };
 
 type Props = {
@@ -31,7 +32,8 @@ class ReactRouterQueryString extends StorageMechanism {
             parse = (data: string): any => JSON.parse(data),
             stringify = (data: any): string => JSON.stringify(data),
             deconstruct,
-            reconstruct
+            reconstruct,
+            memoize = true
         } = config;
 
         const type = 'ReactRouterQueryString';
@@ -49,14 +51,18 @@ class ReactRouterQueryString extends StorageMechanism {
         });
 
         this._method = method;
-        this._parse = deepMemo((str) => {
+        this._parse = (str) => {
             try {
                 return parse(str);
             } catch(e) {
                 return InvalidValueMarker;
             }
-        });
+        };
         this._stringify = stringify;
+
+        if(memoize) {
+            this._parse = deepMemo(this._parse);
+        }
     }
 
     //

--- a/packages/react-cool-storage/src/ReactRouterQueryString.js
+++ b/packages/react-cool-storage/src/ReactRouterQueryString.js
@@ -1,6 +1,7 @@
 // @flow
 import forEach from 'unmutable/forEach';
 import pipeWith from 'unmutable/pipeWith';
+import InvalidValueMarker from './InvalidValueMarker';
 import StorageMechanism from './StorageMechanism';
 import deepMemo from 'deep-memo';
 
@@ -48,7 +49,13 @@ class ReactRouterQueryString extends StorageMechanism {
         });
 
         this._method = method;
-        this._parse = deepMemo(parse);
+        this._parse = deepMemo((str) => {
+            try {
+                return parse(str);
+            } catch(e) {
+                return InvalidValueMarker;
+            }
+        });
         this._stringify = stringify;
     }
 

--- a/packages/react-cool-storage/src/StorageMechanism.js
+++ b/packages/react-cool-storage/src/StorageMechanism.js
@@ -106,7 +106,11 @@ export default class StorageMechanism {
     // public
     //
 
-    get available(): ?string {
+    get available(): ?boolean {
+        return !this.availabilityError;
+    }
+
+    get availabilityError(): ?string {
         return this._requiresProps
             ? `${this._type} requires props and cannot be accessed outside of React`
             : this._availableFromProps();

--- a/packages/react-cool-storage/src/StorageMechanism.js
+++ b/packages/react-cool-storage/src/StorageMechanism.js
@@ -1,16 +1,20 @@
 // @flow
-
+import filter from 'unmutable/lib/filter';
 import identity from 'unmutable/identity';
+import keyArray from 'unmutable/lib/keyArray';
+import isKeyed from 'unmutable/lib/isKeyed';
+import merge from 'unmutable/lib/merge';
+import omit from 'unmutable/lib/omit';
+import pipeWith from 'unmutable/lib/pipeWith';
+
 import Synchronizer from './Synchronizer';
 
 type Config = {
-    storageType: string,
-    checkAvailable: (props: any) => ?string,
-    getValue: (props: any) => any,
-    handleChange?: (handleChangeProps: any) => void,
     deconstruct?: Function,
     reconstruct?: Function,
-    synchronizer: ?Synchronizer,
+    requiresProps: boolean,
+    synchronizer?: Synchronizer,
+    type: string,
     updateFromProps: boolean
 };
 
@@ -20,32 +24,108 @@ type SyncListener = {
 };
 
 export default class StorageMechanism {
-    storageType: string;
-    checkAvailable: (props: any) => ?string;
-    getValue: (props: any) => any;
-    handleChange: (handleChangeProps: any) => void;
-    deconstruct: Function;
-    reconstruct: Function;
-    updateFromProps: boolean;
-    syncListeners: SyncListener[] = [];
-    synchronizer: ?Synchronizer;
 
     constructor(config: Config) {
-        this.storageType = config.storageType;
-        this.checkAvailable = config.checkAvailable;
-        this.getValue = config.getValue;
-        this.handleChange = config.handleChange || identity();
-        this.deconstruct = config.deconstruct || identity();
-        this.reconstruct = config.reconstruct || identity();
-        this.synchronizer = config.synchronizer;
-        this.updateFromProps = config.updateFromProps;
+        this._deconstruct = config.deconstruct || identity();
+        this._reconstruct = config.reconstruct || identity();
+        this._requiresProps = config.requiresProps;
+        this._synchronizer = config.synchronizer;
+        this._type = config.type;
+        this._updateFromProps = config.updateFromProps;
     }
 
-    addSyncListener(callback: (value: any) => void, origin: any) {
-        this.synchronizer && this.synchronizer.addSyncListener(callback, origin);
+    //
+    // private
+    //
+
+    _deconstruct: Function;
+    _props: any;
+    _reconstruct: Function;
+    _requiresProps: boolean;
+    _synchronizer: ?Synchronizer;
+    _type: string;
+    _updateFromProps: boolean;
+
+    _syncListeners: SyncListener[] = [];
+
+    _addSyncListener(callback: (value: any) => void, origin: any) {
+        this._synchronizer && this._synchronizer.addSyncListener(callback, origin);
     }
 
-    removeSyncListener(originToRemove: any) {
-        this.synchronizer && this.synchronizer.removeSyncListener(originToRemove);
+    _removeSyncListener(originToRemove: any) {
+        this._synchronizer && this._synchronizer.removeSyncListener(originToRemove);
+    }
+
+    _onChangeWithOptions(newValue: any, {origin, props}: any = {}): any {
+
+        let value = this._deconstruct(newValue);
+
+        if(!isKeyed(value)) {
+            throw new Error(`${this.type} onChange must be passed an object`);
+        }
+
+        let removedKeys = pipeWith(
+            newValue,
+            filter(_ => typeof _ === "undefined"),
+            keyArray()
+        );
+
+        let changedValues = omit(removedKeys)(value);
+
+        let updatedValue = pipeWith(
+            props ? this._valueFromProps(props) : this.value,
+            merge(changedValues),
+            omit(removedKeys)
+        );
+
+        this._handleChange({
+            updatedValue,
+            changedValues,
+            removedKeys,
+            props,
+            origin
+        });
+
+        return updatedValue;
+    }
+
+    //
+    // private overridables
+    //
+
+    _availableFromProps(props: any /* eslint-disable-line */): ?string {
+    }
+
+    _valueFromProps(props: any /* eslint-disable-line */): any {
+    }
+
+    _handleChange(handleChangeProps: any /* eslint-disable-line */): void {
+    }
+
+    //
+    // public
+    //
+
+    get available(): ?string {
+        return this._requiresProps
+            ? `${this._type} requires props and cannot be accessed outside of React`
+            : this._availableFromProps();
+    }
+
+    get type(): any {
+        return this._type;
+    }
+
+    get value(): any {
+        return this._requiresProps
+            ? {}
+            : this._valueFromProps();
+    }
+
+    onChange(newValue: any): void {
+        if(this._requiresProps) {
+            throw new Error(`${this._type} requires props and cannot be changed outside of React`);
+        }
+        this._onChangeWithOptions(newValue);
     }
 }

--- a/packages/react-cool-storage/src/WebStorage.js
+++ b/packages/react-cool-storage/src/WebStorage.js
@@ -12,7 +12,8 @@ type Config = {
     parse?: (data: string) => any,
     stringify?: (data: any) => string,
     deconstruct?: Function,
-    reconstruct?: Function
+    reconstruct?: Function,
+    memoize?: boolean
 };
 
 const synchronizerMap: {[key: string]: Synchronizer} = {}; // create a global map of synchronizers
@@ -26,7 +27,8 @@ class WebStorage extends StorageMechanism {
             parse = (data: string): any => JSON.parse(data),
             stringify = (data: any): string => JSON.stringify(data),
             deconstruct,
-            reconstruct
+            reconstruct,
+            memoize = true
         } = config;
 
         const type = 'WebStorage';
@@ -54,15 +56,18 @@ class WebStorage extends StorageMechanism {
 
         this._key = key;
         this._method = method;
-        this._parse = deepMemo((str) => {
+        this._parse = (str) => {
             try {
                 return parse(str) || {};
             } catch(e) {
                 return InvalidValueMarker;
             }
-        });
+        };
         this._stringify = stringify;
 
+        if(memoize) {
+            this._parse = deepMemo(this._parse);
+        }
     }
 
     //

--- a/packages/react-cool-storage/src/WebStorage.js
+++ b/packages/react-cool-storage/src/WebStorage.js
@@ -13,59 +13,90 @@ type Config = {
     reconstruct?: Function
 };
 
-const storageType = 'WebStorage';
-
 const synchronizerMap: {[key: string]: Synchronizer} = {}; // create a global map of synchronizers
 
-export default (config: Config): StorageMechanism => {
-    let {
-        key,
-        method = "localStorage",
-        parse = (data: string): any => JSON.parse(data),
-        stringify = (data: any): string => JSON.stringify(data),
-        deconstruct,
-        reconstruct
-    } = config;
+class WebStorage extends StorageMechanism {
 
-    if(typeof key !== "string") {
-        throw new Error(`${storageType} expects param "config.key" to be a string, but got ${typeof key}`);
-    }
+    constructor(config: Config) {
+        let {
+            key,
+            method = "localStorage",
+            parse = (data: string): any => JSON.parse(data),
+            stringify = (data: any): string => JSON.stringify(data),
+            deconstruct,
+            reconstruct
+        } = config;
 
-    if(method !== "localStorage" && method !== "sessionStorage") {
-        throw new Error(`${storageType} expects param "config.method" to be either "localStorage" or "sessionStorage"`);
-    }
+        const type = 'WebStorage';
 
-    if(!synchronizerMap[key]) {
-        synchronizerMap[key] = new Synchronizer();
-    }
-
-    let storage = typeof window !== "undefined" && window[method];
-    let getValue = () => parse(storage.getItem(key)) || {};
-
-    let checkAvailable = (): ?string => {
-        if(!storageAvailable(method)) {
-            return `${storageType} requires ${method} to be available`;
+        if(typeof key !== "string") {
+            throw new Error(`${type} expects param "config.key" to be a string, but got ${typeof key}`);
         }
-    };
 
-    let storageMechanism = new StorageMechanism({
-        checkAvailable,
-        getValue,
-        storageType,
-        deconstruct,
-        reconstruct,
-        updateFromProps: false,
-        synchronizer: synchronizerMap[key]
-    });
+        if(method !== "localStorage" && method !== "sessionStorage") {
+            throw new Error(`${type} expects param "config.method" to be either "localStorage" or "sessionStorage"`);
+        }
 
-    storageMechanism.handleChange = ({updatedValue, origin}: *) => {
+        if(!synchronizerMap[key]) {
+            synchronizerMap[key] = new Synchronizer();
+        }
+
+        super({
+            deconstruct,
+            reconstruct,
+            requiresProps: false,
+            synchronizer: synchronizerMap[key],
+            type,
+            updateFromProps: false
+        });
+
+        this._key = key;
+        this._method = method;
+        this._parse = parse;
+        this._stringify = stringify;
+    }
+
+    //
+    // private
+    //
+
+    _key: string;
+    _method: "localStorage"|"sessionStorage";
+    _parse: (data: string) => any;
+    _stringify: (data: any) => string;
+
+    //
+    // private overrides
+    //
+
+    _availableFromProps(props: any /* eslint-disable-line */): ?string {
+        if(!storageAvailable(this._method)) {
+            return `${this._type} requires ${this._method} to be available`;
+        }
+    }
+
+    _valueFromProps(props: any /* eslint-disable-line */): any {
+        let storage = typeof window !== "undefined" && window[this._method];
+        if(!storage) {
+            return;
+        }
+
+        return this._parse(storage.getItem(this._key)) || {};
+    }
+
+    _handleChange({updatedValue, origin}: any): void {
+        let storage = typeof window !== "undefined" && window[this._method];
+        if(!storage) {
+            return;
+        }
+
         pipeWith(
             updatedValue,
-            stringify,
-            (str: string) => storage.setItem(key, str)
+            this._stringify,
+            (str: string) => storage.setItem(this._key, str)
         );
-        synchronizerMap[key].onSync(updatedValue, origin);
-    };
+        synchronizerMap[this._key].onSync(updatedValue, origin);
+    }
+}
 
-    return storageMechanism;
-};
+export default (config: Config): StorageMechanism => new WebStorage(config);

--- a/packages/react-cool-storage/src/WebStorage.js
+++ b/packages/react-cool-storage/src/WebStorage.js
@@ -1,6 +1,7 @@
 // @flow
 import storageAvailable from 'storage-available';
 import pipeWith from 'unmutable/pipeWith';
+import InvalidValueMarker from './InvalidValueMarker';
 import StorageMechanism from './StorageMechanism';
 import Synchronizer from './Synchronizer';
 import deepMemo from 'deep-memo';
@@ -53,7 +54,13 @@ class WebStorage extends StorageMechanism {
 
         this._key = key;
         this._method = method;
-        this._parse = deepMemo((data) => parse(data) || {});
+        this._parse = deepMemo((str) => {
+            try {
+                return parse(str) || {};
+            } catch(e) {
+                return InvalidValueMarker;
+            }
+        });
         this._stringify = stringify;
 
     }

--- a/packages/react-cool-storage/src/__test__/MemoryStorage-test.js
+++ b/packages/react-cool-storage/src/__test__/MemoryStorage-test.js
@@ -166,3 +166,45 @@ test('MemoryStorage should not synchronize when using different memoryStorage in
     expect(value2).toEqual({});
 });
 
+
+//
+// usage outside React
+//
+
+test('MemoryStorage available should be accessible from MemoryStorage instance', () => {
+    let memoryStorage = MemoryStorage();
+    expect(memoryStorage.available).toBe(true);
+});
+
+
+test('MemoryStorage availabilityError should be undefined on MemoryStorage instance', () => {
+    let memoryStorage = MemoryStorage();
+    expect(memoryStorage.availabilityError).toBe(undefined);
+});
+
+test('MemoryStorage value should be accessible from MemoryStorage instance', () => {
+    let memoryStorage = MemoryStorage({
+        initialValue: {abc: 123}
+    });
+    expect(memoryStorage.value).toEqual({abc: 123});
+});
+
+test('MemoryStorage value should be changeable from MemoryStorage instance', () => {
+    let wrapper = shallowRenderHoc(
+        {},
+        ReactCoolStorageHoc("storage", MemoryStorage())
+    );
+
+    let memoryStorage = MemoryStorage();
+
+    memoryStorage.onChange({abc: 456});
+
+    let value = wrapper
+        .props()
+        .storage
+        .value;
+
+    expect(memoryStorage.value).toEqual({abc: 456});
+});
+
+

--- a/packages/react-cool-storage/src/__test__/ReachRouterQueryString-test.js
+++ b/packages/react-cool-storage/src/__test__/ReachRouterQueryString-test.js
@@ -161,14 +161,14 @@ test('ReachRouterQueryString should pass its value through config.reconstruct', 
     expect(childProps.query.value.date.getTime()).toBe(date.getTime());
 });
 
-test('ReachRouterQueryString should pass each value through config.parse', () => {
-    let parse = (str: string) => JSON.parse(str.slice(1));
+test('ReachRouterQueryString should pass value through config.parse', () => {
+    let parse = (str: string) =>  JSON.parse(str.replace("abc", "ABC"));
 
     let childProps = shallowRenderHoc(
         {
             location: {
                 pathname: "/abc",
-                search: "?abc=A123&def=A456"
+                search: "?abc=123&def=456"
             }
         },
         ReactCoolStorageHoc("query", ReachRouterQueryString({
@@ -181,7 +181,7 @@ test('ReachRouterQueryString should pass each value through config.parse', () =>
     expect(childProps.query.valid).toBe(true);
 
     expect(childProps.query.value).toEqual({
-        abc: 123,
+        ABC: 123,
         def: 456
     });
 });
@@ -365,6 +365,91 @@ test('ReachRouterQueryString should pass each changed value through config.strin
     expect(navigate).toHaveBeenCalled();
     expect(navigate.mock.calls[0][0]).toBe("/abc?abc=A456&def=A789");
 });
+
+//
+// Memoization
+//
+
+let navigateOnChange = (wrapper, navigate, prop, newValue) => {
+    wrapper.props()[prop].onChange(newValue);
+    let pathname = wrapper.props().location.pathname;
+    wrapper.setProps({
+        location: {
+            pathname,
+            search: navigate.mock.calls[navigate.mock.calls.length - 1][0].slice(pathname.length)
+        }
+    });
+    wrapper.update();
+};
+
+test('ReachRouterQueryString should memoize properly', () => {
+    let navigate = jest.fn();
+
+    let wrapper = shallowRenderHoc(
+        {
+            location: {
+                pathname: "/abc",
+                search: "?abc=123"
+            }
+        },
+        ReactCoolStorageHoc("query", ReachRouterQueryString({
+            navigate
+        }))
+    );
+
+    let firstValue = wrapper.props().query.value;
+
+    navigateOnChange(wrapper, navigate, "query", {abc: 123});
+
+    let secondValue = wrapper.props().query.value;
+
+    expect(firstValue).toEqual(secondValue);
+    expect(firstValue).toBe(secondValue);
+
+    navigateOnChange(wrapper, navigate, "query", {abc: 123});
+
+    let thirdValue = wrapper.props().query.value;
+
+    expect(secondValue).toEqual(thirdValue);
+    expect(secondValue).toBe(thirdValue);
+});
+
+test('ReachRouterQueryString should memoize partially', () => {
+    let navigate = jest.fn();
+
+    let wrapper = shallowRenderHoc(
+        {
+            location: {
+                pathname: "/abc",
+                search: "?abc=%5B123%2C456%5D&def=%5B100%2C200%5D"
+            }
+        },
+        ReactCoolStorageHoc("query", ReachRouterQueryString({
+            navigate
+        }))
+    );
+
+    let firstValue = wrapper.props().query.value;
+
+    navigateOnChange(wrapper, navigate, "query", {abc: [123, 456], def: [100, 200]});
+
+    let secondValue = wrapper.props().query.value;
+
+    expect(firstValue.abc).toEqual(secondValue.abc);
+    expect(firstValue.abc).toBe(secondValue.abc);
+    expect(firstValue.def).toEqual(secondValue.def);
+    expect(firstValue.def).toBe(secondValue.def);
+
+    navigateOnChange(wrapper, navigate, "query", {abc: [123, 789], def: [100, 200]});
+
+    let thirdValue = wrapper.props().query.value;
+
+    expect(secondValue.abc).not.toEqual(thirdValue.abc);
+    expect(secondValue.abc).not.toBe(thirdValue.abc);
+    expect(secondValue.def).toEqual(thirdValue.def);
+    expect(secondValue.def).toBe(thirdValue.def);
+});
+
 
 //
 // Data types

--- a/packages/react-cool-storage/src/__test__/ReachRouterQueryString-test.js
+++ b/packages/react-cool-storage/src/__test__/ReachRouterQueryString-test.js
@@ -414,6 +414,32 @@ test('ReachRouterQueryString should memoize properly', () => {
     expect(secondValue).toBe(thirdValue);
 });
 
+test('ReachRouterQueryString should not memoize if config.memoize = false', () => {
+    let navigate = jest.fn();
+
+    let wrapper = shallowRenderHoc(
+        {
+            location: {
+                pathname: "/abc",
+                search: "?abc=123"
+            }
+        },
+        ReactCoolStorageHoc("query", ReachRouterQueryString({
+            navigate,
+            memoize: false
+        }))
+    );
+
+    let firstValue = wrapper.props().query.value;
+
+    navigateOnChange(wrapper, navigate, "query", {abc: 123});
+
+    let secondValue = wrapper.props().query.value;
+
+    expect(firstValue).toEqual(secondValue);
+    expect(firstValue).not.toBe(secondValue);
+});
+
 test('ReachRouterQueryString should memoize partially', () => {
     let navigate = jest.fn();
 

--- a/packages/react-cool-storage/src/__test__/ReactRouterQueryString-test.js
+++ b/packages/react-cool-storage/src/__test__/ReactRouterQueryString-test.js
@@ -460,6 +460,33 @@ test('ReactRouterQueryString should memoize properly', () => {
     expect(secondValue).toBe(thirdValue);
 });
 
+test('ReactRouterQueryString should not memoize if config.memoize = false', () => {
+    let push = jest.fn();
+
+    let wrapper = shallowRenderHoc(
+        {
+            history: {
+                push
+            },
+            location: {
+                search: "?abc=123"
+            }
+        },
+        ReactCoolStorageHoc("query", ReactRouterQueryString({
+            memoize: false
+        }))
+    );
+
+    let firstValue = wrapper.props().query.value;
+
+    pushOnChange(wrapper, push, "query", {abc: 123});
+
+    let secondValue = wrapper.props().query.value;
+
+    expect(firstValue).toEqual(secondValue);
+    expect(firstValue).not.toBe(secondValue);
+});
+
 test('ReactRouterQueryString should memoize partially', () => {
     let push = jest.fn();
 

--- a/packages/react-cool-storage/src/__test__/ReactRouterQueryString-test.js
+++ b/packages/react-cool-storage/src/__test__/ReactRouterQueryString-test.js
@@ -178,8 +178,8 @@ test('ReactRouterQueryString should pass its value through config.reconstruct', 
     expect(childProps.query.value.date.getTime()).toBe(date.getTime());
 });
 
-test('ReactRouterQueryString should pass each value through config.parse', () => {
-    let parse = (str: string) => JSON.parse(str.slice(1));
+test('ReactRouterQueryString should pass value through config.parse', () => {
+    let parse = (str: string) => JSON.parse(str.replace("abc", "ABC"));
 
     let childProps = shallowRenderHoc(
         {
@@ -188,11 +188,10 @@ test('ReactRouterQueryString should pass each value through config.parse', () =>
                 replace: () => {}
             },
             location: {
-                search: "?abc=A123&def=A456"
+                search: "?abc=123&def=456"
             }
         },
         ReactCoolStorageHoc("query", ReactRouterQueryString({
-            name: "query",
             parse
         }))
     ).props();
@@ -201,7 +200,7 @@ test('ReactRouterQueryString should pass each value through config.parse', () =>
     expect(childProps.query.valid).toBe(true);
 
     expect(childProps.query.value).toEqual({
-        abc: 123,
+        ABC: 123,
         def: 456
     });
 });
@@ -410,6 +409,91 @@ test('ReactRouterQueryString should pass each changed value through config.strin
     expect(push).toHaveBeenCalled();
     expect(replace).not.toHaveBeenCalled();
     expect(push.mock.calls[0][0]).toBe("?abc=A456&def=A789");
+});
+
+//
+// Memoization
+//
+
+let pushOnChange = (wrapper, push, prop, newValue) => {
+    wrapper.props()[prop].onChange(newValue);
+    wrapper.setProps({
+        history: {
+            push
+        },
+        location: {
+            search: push.mock.calls[push.mock.calls.length - 1][0]
+        }
+    });
+    wrapper.update();
+};
+
+test('ReactRouterQueryString should memoize properly', () => {
+    let push = jest.fn();
+
+    let wrapper = shallowRenderHoc(
+        {
+            history: {
+                push
+            },
+            location: {
+                search: "?abc=123"
+            }
+        },
+        ReactCoolStorageHoc("query", ReactRouterQueryString())
+    );
+
+    let firstValue = wrapper.props().query.value;
+
+    pushOnChange(wrapper, push, "query", {abc: 123});
+
+    let secondValue = wrapper.props().query.value;
+
+    expect(firstValue).toEqual(secondValue);
+    expect(firstValue).toBe(secondValue);
+
+    pushOnChange(wrapper, push, "query", {abc: 123});
+
+    let thirdValue = wrapper.props().query.value;
+
+    expect(secondValue).toEqual(thirdValue);
+    expect(secondValue).toBe(thirdValue);
+});
+
+test('ReactRouterQueryString should memoize partially', () => {
+    let push = jest.fn();
+
+    let wrapper = shallowRenderHoc(
+        {
+            history: {
+                push
+            },
+            location: {
+                search: "?abc=%5B123%2C456%5D&def=%5B100%2C200%5D"
+            }
+        },
+        ReactCoolStorageHoc("query", ReactRouterQueryString())
+    );
+
+    let firstValue = wrapper.props().query.value;
+
+    pushOnChange(wrapper, push, "query", {abc: [123, 456], def: [100, 200]});
+
+    let secondValue = wrapper.props().query.value;
+
+    expect(firstValue.abc).toEqual(secondValue.abc);
+    expect(firstValue.abc).toBe(secondValue.abc);
+    expect(firstValue.def).toEqual(secondValue.def);
+    expect(firstValue.def).toBe(secondValue.def);
+
+    pushOnChange(wrapper, push, "query", {abc: [123, 789], def: [100, 200]});
+
+    let thirdValue = wrapper.props().query.value;
+
+    expect(secondValue.abc).not.toEqual(thirdValue.abc);
+    expect(secondValue.abc).not.toBe(thirdValue.abc);
+    expect(secondValue.def).toEqual(thirdValue.def);
+    expect(secondValue.def).toBe(thirdValue.def);
 });
 
 //

--- a/packages/react-cool-storage/src/__test__/WebStorage-test.js
+++ b/packages/react-cool-storage/src/__test__/WebStorage-test.js
@@ -423,4 +423,41 @@ test('WebStorage should not sync hocs when different keys are used', () => {
     expect(value2).toEqual({});
 });
 
+//
+// usage outside React
+//
+
+test('WebStorage value should be accessible from WebStorage instance', () => {
+    localStorage.setItem("localStorageKey", `{"abc":123}`);
+
+    let webStorage = WebStorage({
+        key: "localStorageKey"
+    });
+
+    expect(webStorage.value).toEqual({abc: 123});
+});
+
+test('WebStorage value should be changeable from WebStorage instance', () => {
+    localStorage.setItem("localStorageKey", `{"abc":123}`);
+
+    let wrapper = shallowRenderHoc(
+        {},
+        ReactCoolStorageHoc("storage", WebStorage({
+            key: "localStorageKey"
+        }))
+    );
+
+    let webStorage = WebStorage({
+        key: "localStorageKey"
+    });
+
+    webStorage.onChange({abc: 456});
+
+    let value = wrapper
+        .props()
+        .storage
+        .value;
+
+    expect(webStorage.value).toEqual({abc: 456});
+});
 

--- a/packages/react-cool-storage/src/__test__/WebStorage-test.js
+++ b/packages/react-cool-storage/src/__test__/WebStorage-test.js
@@ -308,6 +308,68 @@ test('WebStorage should pass the value through config.stringify', () => {
 });
 
 //
+// Memoization
+//
+
+test('WebStorage should memoize properly', () => {
+    localStorage.setItem("localStorageKey", `{"abc":123}`);
+
+    let wrapper = shallowRenderHoc(
+        {},
+        ReactCoolStorageHoc("storage", WebStorage({
+            key: "localStorageKey"
+        }))
+    );
+
+    let firstValue = wrapper.props().storage.value;
+
+    wrapper.props().storage.onChange({abc: 123});
+    wrapper.update();
+
+    let secondValue = wrapper.props().storage.value;
+
+    expect(firstValue).toEqual(secondValue);
+    expect(firstValue).toBe(secondValue);
+
+    wrapper.props().storage.onChange({abc: 123});
+    wrapper.update();
+
+    let thirdValue = wrapper.props().storage.value;
+
+    expect(secondValue).toEqual(thirdValue);
+    expect(secondValue).toBe(thirdValue);
+});
+
+test('WebStorage should memoize partially', () => {
+    localStorage.setItem("localStorageKey", `{"abc":[123, 456], "def": "foo"}`);
+
+    let wrapper = shallowRenderHoc(
+        {},
+        ReactCoolStorageHoc("storage", WebStorage({
+            key: "localStorageKey"
+        }))
+    );
+
+    let firstValue = wrapper.props().storage.value.abc;
+
+    wrapper.props().storage.onChange({abc: [123, 456], def: "bar"});
+    wrapper.update();
+
+    let secondValue = wrapper.props().storage.value.abc;
+
+    expect(firstValue).toEqual(secondValue);
+    expect(firstValue).toBe(secondValue);
+
+    wrapper.props().storage.onChange({abc: [123, 789], def: "bar"});
+    wrapper.update();
+
+    let thirdValue = wrapper.props().storage.value.abc;
+
+    expect(secondValue).not.toEqual(thirdValue);
+    expect(secondValue).not.toBe(thirdValue);
+});
+
+//
 // Data types
 //
 
@@ -470,4 +532,3 @@ test('WebStorage value should be changeable from WebStorage instance', () => {
 
     expect(webStorage.value).toEqual({abc: 456});
 });
-

--- a/packages/react-cool-storage/src/__test__/WebStorage-test.js
+++ b/packages/react-cool-storage/src/__test__/WebStorage-test.js
@@ -427,6 +427,16 @@ test('WebStorage should not sync hocs when different keys are used', () => {
 // usage outside React
 //
 
+test('WebStorage available should be accessible from WebStorage instance', () => {
+    localStorage.setItem("localStorageKey", `{"abc":123}`);
+
+    let webStorage = WebStorage({
+        key: "localStorageKey"
+    });
+
+    expect(webStorage.available).toBe(true);
+});
+
 test('WebStorage value should be accessible from WebStorage instance', () => {
     localStorage.setItem("localStorageKey", `{"abc":123}`);
 

--- a/packages/react-cool-storage/src/__test__/WebStorage-test.js
+++ b/packages/react-cool-storage/src/__test__/WebStorage-test.js
@@ -369,6 +369,28 @@ test('WebStorage should memoize partially', () => {
     expect(secondValue).not.toBe(thirdValue);
 });
 
+test('WebStorage should not memoize if config.memoize = false', () => {
+    localStorage.setItem("localStorageKey", `{"abc":123}`);
+
+    let wrapper = shallowRenderHoc(
+        {},
+        ReactCoolStorageHoc("storage", WebStorage({
+            key: "localStorageKey",
+            memoize: false
+        }))
+    );
+
+    let firstValue = wrapper.props().storage.value;
+
+    wrapper.props().storage.onChange({abc: 123});
+    wrapper.update();
+
+    let secondValue = wrapper.props().storage.value;
+
+    expect(firstValue).toEqual(secondValue);
+    expect(firstValue).not.toBe(secondValue);
+});
+
 //
 // Data types
 //

--- a/packages/react-cool-storage/yarn.lock
+++ b/packages/react-cool-storage/yarn.lock
@@ -5393,9 +5393,9 @@ universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
 
-unmutable@^0.43.0:
-  version "0.43.1"
-  resolved "https://registry.yarnpkg.com/unmutable/-/unmutable-0.43.1.tgz#71f8cbca2f8dc04759b60442d9b1626cbecad7be"
+unmutable@^0.44.0:
+  version "0.44.0"
+  resolved "https://registry.yarnpkg.com/unmutable/-/unmutable-0.44.0.tgz#7c606fd085159142877a1ae7cefcf6fb098c3a4e"
   dependencies:
     "@babel/runtime" "^7.1.5"
     fast-deep-equal "^1.0.0"

--- a/packages/react-cool-storage/yarn.lock
+++ b/packages/react-cool-storage/yarn.lock
@@ -1650,6 +1650,16 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
 
+deep-memo@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/deep-memo/-/deep-memo-0.1.2.tgz#562f30661b31c221a6ba53da574b46b5fdf17cfd"
+  dependencies:
+    "@babel/runtime" "^7.1.5"
+    fast-deep-equal "^1.0.0"
+    is-plain-object "^2.0.4"
+    lodash.range "^3.2.0"
+    unmutable "^0.45.1"
+
 default-require-extensions@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-1.0.0.tgz#f37ea15d3e13ffd9b437d33e1a75b5fb97874cb8"
@@ -5393,9 +5403,9 @@ universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
 
-unmutable@^0.44.0:
-  version "0.44.0"
-  resolved "https://registry.yarnpkg.com/unmutable/-/unmutable-0.44.0.tgz#7c606fd085159142877a1ae7cefcf6fb098c3a4e"
+unmutable@^0.45.1:
+  version "0.45.1"
+  resolved "https://registry.yarnpkg.com/unmutable/-/unmutable-0.45.1.tgz#182ded785db16a2947758518b0eebd4d3cf6566f"
   dependencies:
     "@babel/runtime" "^7.1.5"
     fast-deep-equal "^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,12 +2,6 @@
 # yarn lockfile v1
 
 
-"@babel/runtime@^7.1.5":
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.0.tgz#d523416573f19aa12784639e631257c7fc58c0aa"
-  dependencies:
-    regenerator-runtime "^0.13.2"
-
 "@commitlint/cli@^7.2.1":
   version "7.5.2"
   resolved "https://registry.yarnpkg.com/@commitlint/cli/-/cli-7.5.2.tgz#2475cd8f7ed3b2f9c2ab96c06bc24d61d23f8716"
@@ -1437,16 +1431,6 @@ dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
 
-deep-memo@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/deep-memo/-/deep-memo-0.1.0.tgz#4efd579eb936621ed45d64e741311f9198d9125c"
-  dependencies:
-    "@babel/runtime" "^7.1.5"
-    fast-deep-equal "^1.0.0"
-    is-plain-object "^2.0.4"
-    lodash.range "^3.2.0"
-    unmutable "^0.44.1"
-
 deepmerge@3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-3.2.0.tgz#58ef463a57c08d376547f8869fdc5bcee957f44e"
@@ -1655,10 +1639,6 @@ extsprintf@1.3.0:
 extsprintf@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
-
-fast-deep-equal@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
 
 fast-deep-equal@^2.0.1:
   version "2.0.1"
@@ -2514,10 +2494,6 @@ lodash.clonedeep@^4.5.0:
 lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
-
-lodash.range@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.range/-/lodash.range-3.2.0.tgz#f461e588f66683f7eadeade513e38a69a565a15d"
 
 lodash.set@^4.3.2:
   version "4.3.2"
@@ -3465,10 +3441,6 @@ regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 
-regenerator-runtime@^0.13.2:
-  version "0.13.2"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz#32e59c9a6fb9b1a4aff09b4930ca2d4477343447"
-
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c"
@@ -4072,15 +4044,6 @@ universal-user-agent@^2.0.0, universal-user-agent@^2.0.1:
 universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
-
-unmutable@^0.44.1:
-  version "0.44.1"
-  resolved "https://registry.yarnpkg.com/unmutable/-/unmutable-0.44.1.tgz#5ab44fefff156abdab04d69e3407570a907fc8fc"
-  dependencies:
-    "@babel/runtime" "^7.1.5"
-    fast-deep-equal "^1.0.0"
-    is-plain-object "^2.0.4"
-    lodash.range "^3.2.0"
 
 unset-value@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,12 @@
 # yarn lockfile v1
 
 
+"@babel/runtime@^7.1.5":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.0.tgz#d523416573f19aa12784639e631257c7fc58c0aa"
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@commitlint/cli@^7.2.1":
   version "7.5.2"
   resolved "https://registry.yarnpkg.com/@commitlint/cli/-/cli-7.5.2.tgz#2475cd8f7ed3b2f9c2ab96c06bc24d61d23f8716"
@@ -1431,6 +1437,16 @@ dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
 
+deep-memo@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/deep-memo/-/deep-memo-0.1.0.tgz#4efd579eb936621ed45d64e741311f9198d9125c"
+  dependencies:
+    "@babel/runtime" "^7.1.5"
+    fast-deep-equal "^1.0.0"
+    is-plain-object "^2.0.4"
+    lodash.range "^3.2.0"
+    unmutable "^0.44.1"
+
 deepmerge@3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-3.2.0.tgz#58ef463a57c08d376547f8869fdc5bcee957f44e"
@@ -1639,6 +1655,10 @@ extsprintf@1.3.0:
 extsprintf@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
+
+fast-deep-equal@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
 
 fast-deep-equal@^2.0.1:
   version "2.0.1"
@@ -2494,6 +2514,10 @@ lodash.clonedeep@^4.5.0:
 lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+
+lodash.range@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.range/-/lodash.range-3.2.0.tgz#f461e588f66683f7eadeade513e38a69a565a15d"
 
 lodash.set@^4.3.2:
   version "4.3.2"
@@ -3441,6 +3465,10 @@ regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 
+regenerator-runtime@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz#32e59c9a6fb9b1a4aff09b4930ca2d4477343447"
+
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c"
@@ -4044,6 +4072,15 @@ universal-user-agent@^2.0.0, universal-user-agent@^2.0.1:
 universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
+
+unmutable@^0.44.1:
+  version "0.44.1"
+  resolved "https://registry.yarnpkg.com/unmutable/-/unmutable-0.44.1.tgz#5ab44fefff156abdab04d69e3407570a907fc8fc"
+  dependencies:
+    "@babel/runtime" "^7.1.5"
+    fast-deep-equal "^1.0.0"
+    is-plain-object "^2.0.4"
+    lodash.range "^3.2.0"
 
 unset-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
- add: deep memoization for StorageMechanisms that parse
- add: Use inheritance to make StorageMechanisms usable outside of React

For StorageMechanisms that don't require props, it will be really useful to use these outside of React.
To do this StorageMechanisms now use inheritance instances of StorageMechanisms
are usable in isolation from ReactCoolStorageHoc.