### PR TITLE
Feature/no merge

### DIFF
--- a/packages/react-cool-storage-docs/src/example/MemoryStorageExample.jsx
+++ b/packages/react-cool-storage-docs/src/example/MemoryStorageExample.jsx
@@ -7,7 +7,7 @@ const MyMemoryStorage = MemoryStorage();
 const useStorage = ReactCoolStorageHook(MyMemoryStorage);
 
 export default (props) => {
-    let memoryStorage = useStorage(props);
+    let memoryStorage = useStorage();
 
     return <div>
         <label>Data stored in memory</label>

--- a/packages/react-cool-storage-docs/src/example/MemoryStorageExample.jsx
+++ b/packages/react-cool-storage-docs/src/example/MemoryStorageExample.jsx
@@ -10,19 +10,10 @@ export default (props) => {
     let memoryStorage = useStorage(props);
 
     return <div>
-        <label>Data stored under a key of "foo"</label>
+        <label>Data stored in memory</label>
         <input
-            value={memoryStorage.value.foo || ""}
-            onChange={(event) => memoryStorage.onChange({
-                foo: event.currentTarget.value
-            })}
-        />
-        <label>Data stored under a key of "bar"</label>
-        <input
-            value={memoryStorage.value.bar || ""}
-            onChange={(event) => memoryStorage.onChange({
-                bar: event.currentTarget.value
-            })}
+            value={memoryStorage.value || ""}
+            onChange={(event) => memoryStorage.set(event.currentTarget.value)}
         />
     </div>;
 };

--- a/packages/react-cool-storage-docs/src/example/ReachRouterStorageExample.jsx
+++ b/packages/react-cool-storage-docs/src/example/ReachRouterStorageExample.jsx
@@ -18,16 +18,18 @@ export default (props) => {
         <label>query string "foo"</label>
         <input
             value={query.value.foo || ""}
-            onChange={(event) => query.onChange({
+            onChange={(event) => query.onChange((prev) => ({
+                ...prev,
                 foo: event.currentTarget.value
-            })}
+            }))}
         />
         <label>query string "bar"</label>
         <input
             value={query.value.bar || ""}
-            onChange={(event) => query.onChange({
+            onChange={(event) => query.onChange((prev) => ({
+                ...prev,
                 bar: event.currentTarget.value
-            })}
+            }))}
         />
     </div>;
 };

--- a/packages/react-cool-storage-docs/src/example/ReachRouterStorageExample.jsx
+++ b/packages/react-cool-storage-docs/src/example/ReachRouterStorageExample.jsx
@@ -18,7 +18,7 @@ export default (props) => {
         <label>query string "foo"</label>
         <input
             value={query.value.foo || ""}
-            onChange={(event) => query.onChange((prev) => ({
+            onChange={(event) => query.set((prev) => ({
                 ...prev,
                 foo: event.currentTarget.value
             }))}
@@ -26,7 +26,7 @@ export default (props) => {
         <label>query string "bar"</label>
         <input
             value={query.value.bar || ""}
-            onChange={(event) => query.onChange((prev) => ({
+            onChange={(event) => query.set((prev) => ({
                 ...prev,
                 bar: event.currentTarget.value
             }))}

--- a/packages/react-cool-storage-docs/src/example/ReactCoolStorageHocSource.txt
+++ b/packages/react-cool-storage-docs/src/example/ReactCoolStorageHocSource.txt
@@ -16,14 +16,14 @@ const MyComponent = (props) => {
         <label>query string "foo"</label>
         <input
             value={query.value.foo || ""}
-            onChange={(event) => query.onChange({
+            onChange={(event) => query.set({
                 foo: event.currentTarget.value
             })}
         />
         <label>query string "bar"</label>
         <input
             value={query.value.bar || ""}
-            onChange={(event) => query.onChange({
+            onChange={(event) => query.set({
                 bar: event.currentTarget.value
             })}
         />

--- a/packages/react-cool-storage-docs/src/example/ReactCoolStorageHookSource.txt
+++ b/packages/react-cool-storage-docs/src/example/ReactCoolStorageHookSource.txt
@@ -15,14 +15,14 @@ export default (props) => {
         <label>localStorage foo</label>
         <input
             value={localStorage.value.foo || ""}
-            onChange={(event) => localStorage.onChange({
+            onChange={(event) => localStorage.set({
                 foo: event.currentTarget.value
             })}
         />
         <label>localStorage bar</label>
         <input
             value={localStorage.value.bar || ""}
-            onChange={(event) => localStorage.onChange({
+            onChange={(event) => localStorage.set({
                 bar: event.currentTarget.value
             })}
         />

--- a/packages/react-cool-storage-docs/src/example/ReactRouterStorageExample.jsx
+++ b/packages/react-cool-storage-docs/src/example/ReactRouterStorageExample.jsx
@@ -16,16 +16,18 @@ export default (props) => {
         <label>query string "foo"</label>
         <input
             value={query.value.foo || ""}
-            onChange={(event) => query.onChange({
+            onChange={(event) => query.onChange((prev) => ({
+                ...prev,
                 foo: event.currentTarget.value
-            })}
+            }))}
         />
         <label>query string "bar"</label>
         <input
             value={query.value.bar || ""}
-            onChange={(event) => query.onChange({
+            onChange={(event) => query.onChange((prev) => ({
+                ...prev,
                 bar: event.currentTarget.value
-            })}
+            }))}
         />
     </div>;
 };

--- a/packages/react-cool-storage-docs/src/example/ReactRouterStorageExample.jsx
+++ b/packages/react-cool-storage-docs/src/example/ReactRouterStorageExample.jsx
@@ -16,7 +16,7 @@ export default (props) => {
         <label>query string "foo"</label>
         <input
             value={query.value.foo || ""}
-            onChange={(event) => query.onChange((prev) => ({
+            onChange={(event) => query.set((prev) => ({
                 ...prev,
                 foo: event.currentTarget.value
             }))}
@@ -24,7 +24,7 @@ export default (props) => {
         <label>query string "bar"</label>
         <input
             value={query.value.bar || ""}
-            onChange={(event) => query.onChange((prev) => ({
+            onChange={(event) => query.set((prev) => ({
                 ...prev,
                 bar: event.currentTarget.value
             }))}

--- a/packages/react-cool-storage-docs/src/example/WebStorageExample.jsx
+++ b/packages/react-cool-storage-docs/src/example/WebStorageExample.jsx
@@ -13,19 +13,10 @@ export default (props) => {
     let webStorage = useStorage(props);
 
     return <div>
-        <label>localStorage data stored under a key of "exampleStorage.foo"</label>
+        <label>Data stored in localStorage</label>
         <input
-            value={webStorage.value.foo || ""}
-            onChange={(event) => webStorage.onChange({
-                foo: event.currentTarget.value
-            })}
-        />
-        <label>localStorage data stored under a key of "exampleStorage.bar"</label>
-        <input
-            value={webStorage.value.bar || ""}
-            onChange={(event) => webStorage.onChange({
-                bar: event.currentTarget.value
-            })}
+            value={webStorage.value || ""}
+            onChange={(event) => webStorage.set(event.currentTarget.value)}
         />
     </div>;
 };

--- a/packages/react-cool-storage-docs/src/example/WebStorageExample.jsx
+++ b/packages/react-cool-storage-docs/src/example/WebStorageExample.jsx
@@ -10,7 +10,7 @@ const useStorage = ReactCoolStorageHook(
 );
 
 export default (props) => {
-    let webStorage = useStorage(props);
+    let webStorage = useStorage();
 
     return <div>
         <label>Data stored in localStorage</label>

--- a/packages/react-cool-storage-docs/src/pages/api/MemoryStorage.mdx
+++ b/packages/react-cool-storage-docs/src/pages/api/MemoryStorage.mdx
@@ -56,7 +56,7 @@ const MyMemoryStorage = MemoryStorage();
 const useStorage = ReactCoolStorageHook(MyMemoryStorage);
 
 export default (props) => {
-    let memoryStorage = useStorage(props);
+    let memoryStorage = useStorage();
 
     return <div>
         <label>Data stored in memory</label>

--- a/packages/react-cool-storage-docs/src/pages/api/MemoryStorage.mdx
+++ b/packages/react-cool-storage-docs/src/pages/api/MemoryStorage.mdx
@@ -24,12 +24,12 @@ import MemoryStorage from 'react-cool-storage/MemoryStorage';
 ```flow
 MemoryStorage({
     // optional
-    initialValue?: Object|() => Object
+    initialValue?: any|() => any
 })
 ```
 
-* <Param name="initialValue" type="Object|() => Object" optional />
-  If provided a object, or a function that returns an object, `initialValue` will set the value when the storage mechanism is instanciated.
+* <Param name="initialValue" type="any|() => any" optional />
+  If provided, this will set the value when the storage mechanism is instanciated.
 
 ## Resources
 
@@ -43,7 +43,7 @@ MemoryStorage requires no props.
 
 MemoryStorage doesn't require any props, so you can also access and change a MemoryStorage instance's value outside of React. All ReactCoolStorageHocs that use the MemoryStorage will update and stay in sync.
 
-A `MyMemoryStorage` instance has been added to the window. Try running `MyMemoryStorage.onChange({foo: "foo"});` in the console and watch the example update at the top of this page.
+A `MyMemoryStorage` instance has been added to the window. Try running `MyMemoryStorage.set("foo");` in the console and watch the example update at the top of this page.
 
 ## Example using hooks
 
@@ -59,19 +59,10 @@ export default (props) => {
     let memoryStorage = useStorage(props);
 
     return <div>
-        <label>Data stored under a key of "foo"</label>
+        <label>Data stored in memory</label>
         <input
             value={memoryStorage.value.foo || ""}
-            onChange={(event) => memoryStorage.onChange({
-                foo: event.currentTarget.value
-            })}
-        />
-        <label>Data stored under a key of "bar"</label>
-        <input
-            value={memoryStorage.value.bar || ""}
-            onChange={(event) => memoryStorage.onChange({
-                bar: event.currentTarget.value
-            })}
+            onChange={(event) => memoryStorage.set(event.currentTarget.value)}
         />
     </div>;
 };

--- a/packages/react-cool-storage-docs/src/pages/api/ReachRouterStorage.mdx
+++ b/packages/react-cool-storage-docs/src/pages/api/ReachRouterStorage.mdx
@@ -12,7 +12,7 @@ Its value is always an object, and can only store data that is **serializable** 
 
 It is **controlled**, meaning that it will update immediately whenever the data source (the query string) changes.
 
-When calling `onChange()`, setting any key to undefined will remove that key / value pair.
+When calling `set()`, setting any key to undefined will remove that key / value pair.
 
 ```flow
 import ReachRouterStorage from 'react-cool-storage/ReachRouterStorage';
@@ -37,7 +37,7 @@ ReachRouterStorage({
   The `history` method to use. Can be "push" or "replace". Defaults to `"push"`.
 
 * <Param name="pathname" type="boolean" default="false" optional />
-  When set to `true`, the Reach Router `pathname` will be included in the value at `value.pathname`. The pathname can then also be set using `onChange({pathname: "???"})`. Defaults to `false`.
+  When set to `true`, the Reach Router `pathname` will be included in the value at `value.pathname`. The pathname can then also be set using `set({pathname: "???"})`. Defaults to `false`.
 
 * <Param name="deconstruct" type="(data: any) => any" optional />
   Can be used to convert data into a serializable format. It is called before ReachRouterStorage stringifies data when a change occurs.
@@ -89,7 +89,7 @@ export default (props) => {
         <label>query string "foo"</label>
         <input
             value={query.value.foo || ""}
-            onChange={(event) => query.onChange((prev) => ({
+            onChange={(event) => query.set((prev) => ({
                 ...prev,
                 foo: event.currentTarget.value
             }))}
@@ -97,7 +97,7 @@ export default (props) => {
         <label>query string "bar"</label>
         <input
             value={query.value.bar || ""}
-            onChange={(event) => query.onChange((prev) => ({
+            onChange={(event) => query.set((prev) => ({
                 ...prev,
                 bar: event.currentTarget.value
             }))}

--- a/packages/react-cool-storage-docs/src/pages/api/ReachRouterStorage.mdx
+++ b/packages/react-cool-storage-docs/src/pages/api/ReachRouterStorage.mdx
@@ -8,9 +8,11 @@ prop location
 
 ReachRouterStorage gives you an easy to use binding for working with Reach Router. By default it stores your data in the query string, but can be configured to also get and set `pathname`.
 
-It can only store data that is **serializable** and stored as a string, such as via `JSON.stringify()`.
+Its value is always an object, and can only store data that is **serializable** and stored as a string, such as via `JSON.stringify()`.
 
 It is **controlled**, meaning that it will update immediately whenever the data source (the query string) changes.
+
+When calling `onChange()`, setting any key to undefined will remove that key / value pair.
 
 ```flow
 import ReachRouterStorage from 'react-cool-storage/ReachRouterStorage';
@@ -27,7 +29,7 @@ ReachRouterStorage({
     reconstruct?: (data: any) => any,
     parse?: (data: string) => any,
     stringify?: (data: any) => string,
-    memoize?: boolean = true
+    memoize?: boolean = false
 })
 ```
 
@@ -49,8 +51,8 @@ ReachRouterStorage({
 * <Param name="stringify" type="(data: any) => string" optional default="JSON.parse()" />
   A function that is called on the value to turn it from a data shape into a string. Defaults to `JSON.stringify()`.
 
-* <Param name="memoize" type="(data: any) => string" optional default="JSON.parse()" />
-  When true, the result of `parse` will be memoized deeply using [deep-memo](https://www.npmjs.com/package/deep-memo) so that references to objects and arrays will remain unchanged unless their values change. This allows parts of the `value` data object to work seamlessly with React pure components. When false, new objects and arrays will be created every time props change, but if a large amount of data is being parsed then disabling memoization can reduce the computation time of the parsing step. Defaults to true.
+* <Param name="memoize" type="boolean" optional default="false" />
+  When true, the result of `parse` will be memoized deeply using [deep-memo](https://www.npmjs.com/package/deep-memo) so that references to objects and arrays will remain unchanged unless their values change. This allows parts of the `value` data object to work seamlessly with React pure components. When false, new objects and arrays will be created every time props change, but if a large amount of data is being parsed then disabling memoization can reduce the computation time of the parsing step.
 
 ## Resources
 
@@ -87,16 +89,18 @@ export default (props) => {
         <label>query string "foo"</label>
         <input
             value={query.value.foo || ""}
-            onChange={(event) => query.onChange({
+            onChange={(event) => query.onChange((prev) => ({
+                ...prev,
                 foo: event.currentTarget.value
-            })}
+            }))}
         />
         <label>query string "bar"</label>
         <input
             value={query.value.bar || ""}
-            onChange={(event) => query.onChange({
+            onChange={(event) => query.onChange((prev) => ({
+                ...prev,
                 bar: event.currentTarget.value
-            })}
+            }))}
         />
     </div>;
 };

--- a/packages/react-cool-storage-docs/src/pages/api/ReactCoolStorageMessageDescription.mdx
+++ b/packages/react-cool-storage-docs/src/pages/api/ReactCoolStorageMessageDescription.mdx
@@ -2,8 +2,8 @@ import {Param} from 'dcme-style';
 
 ```flow
 ReactCoolStorageMessage {
-    value: Object;
-    onChange: (newPartialValue: Object) => void,
+    value: any;
+    onChange: (newValue: any) => void,
     valid: boolean;
     available: boolean;
     availabilityError: ?string;
@@ -11,12 +11,11 @@ ReactCoolStorageMessage {
 }
 ```
 
-* <Param name="value" type="Object" default="{}" />
+* <Param name="value" type="any" />
   The current value. Defaults to an object with keys and values.
 
-* <Param name="onChange" type="(newPartialValue: Object) => void" />
-  A callback to change the value. Defaults to requiring an object with keys and values. Values are shallowly merged into the exisiting `value`. Setting any key to undefined will remove that key / value pair.
-
+* <Param name="onChange" type="(newValue: any) => void" />
+  A callback to change the value. If you pass `newValue` a function, it will call it with the current value and use the result as the new value.
 * <Param name="valid" type="boolean" />
   Indicates whether the value in the chosen storage is able to be parsed correctly. When false, `value` defaults to an empty object.
 

--- a/packages/react-cool-storage-docs/src/pages/api/ReactCoolStorageMessageDescription.mdx
+++ b/packages/react-cool-storage-docs/src/pages/api/ReactCoolStorageMessageDescription.mdx
@@ -3,7 +3,7 @@ import {Param} from 'dcme-style';
 ```flow
 ReactCoolStorageMessage {
     value: any;
-    onChange: (newValue: any) => void,
+    set: (newValue: any) => void,
     valid: boolean;
     available: boolean;
     availabilityError: ?string;
@@ -14,13 +14,13 @@ ReactCoolStorageMessage {
 * <Param name="value" type="any" />
   The current value. Defaults to an object with keys and values.
 
-* <Param name="onChange" type="(newValue: any) => void" />
+* <Param name="set" type="(newValue: any) => void" />
   A callback to change the value. If you pass `newValue` a function, it will call it with the current value and use the result as the new value.
 * <Param name="valid" type="boolean" />
   Indicates whether the value in the chosen storage is able to be parsed correctly. When false, `value` defaults to an empty object.
 
 * <Param name="available" type="boolean" />
-  Indicates whether any storage mechanism is available to use. When false, `value` defaults to an empty object and `onChange` has no effect.
+  Indicates whether any storage mechanism is available to use. When false, `value` defaults to an empty object and `set` has no effect.
 
 * <Param name="availableError" optional type="string" />
   If no storage mechanisms are available, this contains the error message describing why.

--- a/packages/react-cool-storage-docs/src/pages/api/ReactRouterStorage.mdx
+++ b/packages/react-cool-storage-docs/src/pages/api/ReactRouterStorage.mdx
@@ -13,7 +13,7 @@ Its value is always an object, It can only store data that is **serializable** a
 
 It is **controlled**, meaning that it will update immediately whenever the data source (the query string) changes.
 
-When calling `onChange()`, setting any key to undefined will remove that key / value pair.
+When calling `set()`, setting any key to undefined will remove that key / value pair.
 
 ```flow
 import ReactRouterStorage from 'react-cool-storage/ReactRouterStorage';
@@ -21,7 +21,7 @@ import ReactRouterStorage from 'react-cool-storage/ReactRouterStorage';
 
 ## Config
 
-```
+```flow
 ReactRouterStorage({
     // optional
     method?: string = "push",
@@ -38,7 +38,7 @@ ReactRouterStorage({
   The `history` method to use. Can be "push" or "replace". Defaults to `"push"`.
 
 * <Param name="pathname" type="boolean" default="false" optional />
-  When set to `true`, the React Router `pathname` will be included in the value at `value.pathname`. The pathname can then also be set using `onChange({pathname: "???"})`. Defaults to `false`.
+  When set to `true`, the React Router `pathname` will be included in the value at `value.pathname`. The pathname can then also be set using `set({pathname: "???"})`. Defaults to `false`.
 
 * <Param name="deconstruct" type="(data: any) => any" optional />
   Can be used to convert data into a serializable format. It is called before ReactRouterStorage stringifies data when a change occurs.
@@ -88,7 +88,7 @@ export default (props) => {
         <label>query string "foo"</label>
         <input
             value={query.value.foo || ""}
-            onChange={(event) => query.onChange((prev) => ({
+            onChange={(event) => query.set((prev) => ({
                 ...prev,
                 foo: event.currentTarget.value
             }))}
@@ -96,7 +96,7 @@ export default (props) => {
         <label>query string "bar"</label>
         <input
             value={query.value.bar || ""}
-            onChange={(event) => query.onChange((prev) => ({
+            onChange={(event) => query.set((prev) => ({
                 ...prev,
                 bar: event.currentTarget.value
             }))}

--- a/packages/react-cool-storage-docs/src/pages/api/ReactRouterStorage.mdx
+++ b/packages/react-cool-storage-docs/src/pages/api/ReactRouterStorage.mdx
@@ -9,9 +9,11 @@ prop history
 
 ReactRouterStorage gives you an easy to use binding for working with React Router v4. By default it stores your data in the query string, but can be configured to also get and set `pathname`.
 
-It can only store data that is **serializable** and stored as a string, such as via `JSON.stringify()`.
+Its value is always an object, It can only store data that is **serializable** and stored as a string, such as via `JSON.stringify()`.
 
 It is **controlled**, meaning that it will update immediately whenever the data source (the query string) changes.
+
+When calling `onChange()`, setting any key to undefined will remove that key / value pair.
 
 ```flow
 import ReactRouterStorage from 'react-cool-storage/ReactRouterStorage';
@@ -28,7 +30,7 @@ ReactRouterStorage({
     reconstruct?: (data: any) => any,
     parse?: (data: string) => any,
     stringify?: (data: any) => string,
-    memoize?: boolean = true
+    memoize?: boolean = false
 })
 ```
 
@@ -50,8 +52,8 @@ ReactRouterStorage({
 * <Param name="stringify" type="(data: any) => string" optional default="JSON.parse()" />
   A function that is called on the value to turn it from a data shape into a string. Defaults to `JSON.stringify()`.
 
-* <Param name="memoize" type="(data: any) => string" optional default="JSON.parse()" />
-  When true, the result of `parse` will be memoized deeply using [deep-memo](https://www.npmjs.com/package/deep-memo) so that references to objects and arrays will remain unchanged unless their values change. This allows parts of the `value` data object to work seamlessly with React pure components. When false, new objects and arrays will be created every time props change, but if a large amount of data is being parsed then disabling memoization can reduce the computation time of the parsing step. Defaults to true.
+* <Param name="memoize" type="boolean" optional default="false" />
+  When true, the result of `parse` will be memoized deeply using [deep-memo](https://www.npmjs.com/package/deep-memo) so that references to objects and arrays will remain unchanged unless their values change. This allows parts of the `value` data object to work seamlessly with React pure components. When false, new objects and arrays will be created every time props change, but if a large amount of data is being parsed then disabling memoization can reduce the computation time of the parsing step.
 
 ## Resources
 
@@ -86,16 +88,18 @@ export default (props) => {
         <label>query string "foo"</label>
         <input
             value={query.value.foo || ""}
-            onChange={(event) => query.onChange({
+            onChange={(event) => query.onChange((prev) => ({
+                ...prev,
                 foo: event.currentTarget.value
-            })}
+            }))}
         />
         <label>query string "bar"</label>
         <input
             value={query.value.bar || ""}
-            onChange={(event) => query.onChange({
+            onChange={(event) => query.onChange((prev) => ({
+                ...prev,
                 bar: event.currentTarget.value
-            })}
+            }))}
         />
     </div>;
 };

--- a/packages/react-cool-storage-docs/src/pages/api/WebStorage.mdx
+++ b/packages/react-cool-storage-docs/src/pages/api/WebStorage.mdx
@@ -87,7 +87,7 @@ const useStorage = ReactCoolStorageHook(
 );
 
 export default (props) => {
-    let webStorage = useStorage(props);
+    let webStorage = useStorage();
 
     return <div>
         <label>Data stored in local storage</label>

--- a/packages/react-cool-storage-docs/src/pages/api/WebStorage.mdx
+++ b/packages/react-cool-storage-docs/src/pages/api/WebStorage.mdx
@@ -30,7 +30,7 @@ WebStorage({
     parse?: (data: string) => any,
     stringify?: (data: any) => string,
     memoize?: boolean = true,
-    initialValue?: Object|() => Object
+    initialValue?: any|() => any
 })
 ```
 
@@ -55,8 +55,8 @@ WebStorage({
 * <Param name="memoize" type="(data: any) => string" optional default="JSON.parse()" />
   When true, the result of `parse` will be memoized deeply using [deep-memo](https://www.npmjs.com/package/deep-memo) so that references to objects and arrays will remain unchanged unless their values change. This allows parts of the `value` data object to work seamlessly with React pure components. When false, new objects and arrays will be created every time props change, but if a large amount of data is being parsed then disabling memoization can reduce the computation time of the parsing step. Defaults to true.
 
-* <Param name="initialValue" type="Object|() => Object" optional />
-  If provided a object, or a function that returns an object, `initialValue` will set the value when the storage mechanism is instanciated.
+* <Param name="initialValue" type="any|() => any" optional />
+  If provided, `initialValue` will set the value when the storage mechanism is instanciated.
 
 ## Resources
 WebStorage requires `window.localStorage` or `window.sessionStorage` to be available, depending on the `method` you choose.
@@ -70,7 +70,7 @@ WebStorage requires no props.
 
 WebStorage doesn't require any props, so you can also access and change WebStorage data outside of React. All ReactCoolStorageHocs that use the WebStorage with the same key will update and stay in sync.
 
-`MyWebStorage` has been added to the window on this page. Try running `MyWebStorage.onChange({foo: "foo"});` in the console and watch the example update at the top of this page.
+`MyWebStorage` has been added to the window on this page. Try running `MyWebStorage.set("foo");` in the console and watch the example update at the top of this page.
 
 
 ## Example using hooks
@@ -90,19 +90,10 @@ export default (props) => {
     let webStorage = useStorage(props);
 
     return <div>
-        <label>localStorage data stored under a key of "exampleStorage.foo"</label>
+        <label>Data stored in local storage</label>
         <input
-            value={webStorage.value.foo || ""}
-            onChange={(event) => webStorage.onChange({
-                foo: event.currentTarget.value
-            })}
-        />
-        <label>localStorage data stored under a key of "exampleStorage.bar"</label>
-        <input
-            value={webStorage.value.bar || ""}
-            onChange={(event) => webStorage.onChange({
-                bar: event.currentTarget.value
-            })}
+            value={webStorage.value || ""}
+            onChange={(event) => webStorage.set(event.currentTarget.value)}
         />
     </div>;
 };

--- a/packages/react-cool-storage-docs/src/pages/index.mdx
+++ b/packages/react-cool-storage-docs/src/pages/index.mdx
@@ -17,8 +17,8 @@ React Cool Storage is a collection of React hooks and higher order components th
 - Put them in a [ReactCoolStorageHook](/api/ReactCoolStorageHook) or a [ReactCoolStorageHoc](/api/ReactCoolStorageHoc)
   - Use the hook in a component and it'll return a [ReactCoolStorageMessage](/api/ReactCoolStorageHook/#ReactCoolStorageMessage), or
   - Wrap your component in the hoc and it'll pass down a [ReactCoolStorageMessage](/api/ReactCoolStorageHoc/#ReactCoolStorageMessage) as a prop
-- Get your value using `ReactCoolStorageMessage.value`. This is always an object, which you can fill with whatever data you like.
-- Set your value using `ReactCoolStorageMessage.onChange(newPartialValue)`. This always expects an object, which you can fill with whatever data you like. The new object is shallowly merged onto any existing data.
+- Get your value using `ReactCoolStorageMessage.value`.
+- Set your value using `ReactCoolStorageMessage.onChange(newValue)`. If you pass `newValue` a function, it will call it with the current value and use the result as the new value.
 
 <Divider />
 

--- a/packages/react-cool-storage-docs/src/pages/index.mdx
+++ b/packages/react-cool-storage-docs/src/pages/index.mdx
@@ -18,7 +18,7 @@ React Cool Storage is a collection of React hooks and higher order components th
   - Use the hook in a component and it'll return a [ReactCoolStorageMessage](/api/ReactCoolStorageHook/#ReactCoolStorageMessage), or
   - Wrap your component in the hoc and it'll pass down a [ReactCoolStorageMessage](/api/ReactCoolStorageHoc/#ReactCoolStorageMessage) as a prop
 - Get your value using `ReactCoolStorageMessage.value`.
-- Set your value using `ReactCoolStorageMessage.onChange(newValue)`. If you pass `newValue` a function, it will call it with the current value and use the result as the new value.
+- Set your value using `ReactCoolStorageMessage.set(newValue)`. If you pass `newValue` a function, it will call it with the current value and use the result as the new value.
 
 <Divider />
 

--- a/packages/react-cool-storage-docs/yalc.lock
+++ b/packages/react-cool-storage-docs/yalc.lock
@@ -2,7 +2,7 @@
   "version": "v1",
   "packages": {
     "react-cool-storage": {
-      "signature": "51d9996f522317fec667293c9e3f2eec",
+      "signature": "d3df7b0440b63cbe8b09e1258d9ffb83",
       "file": true,
       "replaced": "^2.1.0"
     }

--- a/packages/react-cool-storage-docs/yalc.lock
+++ b/packages/react-cool-storage-docs/yalc.lock
@@ -2,7 +2,7 @@
   "version": "v1",
   "packages": {
     "react-cool-storage": {
-      "signature": "df50b362cc0d8af705d63955b8eac8cd",
+      "signature": "c2e8ce44a87a5db0996edae7564a209f",
       "file": true,
       "replaced": "^2.1.0"
     }

--- a/packages/react-cool-storage-docs/yalc.lock
+++ b/packages/react-cool-storage-docs/yalc.lock
@@ -2,7 +2,7 @@
   "version": "v1",
   "packages": {
     "react-cool-storage": {
-      "signature": "c2e8ce44a87a5db0996edae7564a209f",
+      "signature": "7ddd043cb9504c817ef8d4b739b86afa",
       "file": true,
       "replaced": "^2.1.0"
     }

--- a/packages/react-cool-storage-docs/yalc.lock
+++ b/packages/react-cool-storage-docs/yalc.lock
@@ -2,7 +2,7 @@
   "version": "v1",
   "packages": {
     "react-cool-storage": {
-      "signature": "d3df7b0440b63cbe8b09e1258d9ffb83",
+      "signature": "df50b362cc0d8af705d63955b8eac8cd",
       "file": true,
       "replaced": "^2.1.0"
     }

--- a/packages/react-cool-storage/InvalidValueMarker.js
+++ b/packages/react-cool-storage/InvalidValueMarker.js
@@ -1,2 +1,2 @@
 /* eslint-disable */
-module.exports = require('./lib/InvalidValueMarker.js');
+module.exports = require('./lib/invalid.js');

--- a/packages/react-cool-storage/package.json
+++ b/packages/react-cool-storage/package.json
@@ -14,7 +14,7 @@
   },
   "files": [
     "lib",
-    "InvalidValueMarker.js",
+    "invalid.js",
     "MemoryStorage.js",
     "ReactCoolStorageHoc.js",
     "ReactCoolStorageMessage.js",

--- a/packages/react-cool-storage/src/InvalidValueMarker.js
+++ b/packages/react-cool-storage/src/InvalidValueMarker.js
@@ -1,4 +1,0 @@
-// @flow
-
-const INVALID_VALUE_MARKER = Symbol('INVALID_VALUE_MARKER');
-export default INVALID_VALUE_MARKER;

--- a/packages/react-cool-storage/src/MemoryStorage.js
+++ b/packages/react-cool-storage/src/MemoryStorage.js
@@ -1,4 +1,6 @@
 // @flow
+import has from 'unmutable/has';
+
 import StorageMechanism from './StorageMechanism';
 import Synchronizer from './Synchronizer';
 
@@ -9,12 +11,11 @@ type Config = {
 class MemoryStorage extends StorageMechanism {
 
     constructor(config: Config) {
-        let {initialValue} = config;
-
         let type = 'MemoryStorage';
 
         super({
             requiresProps: false,
+            requiresKeyed: false,
             synchronizer: new Synchronizer(),
             type,
             updateFromProps: false
@@ -22,7 +23,9 @@ class MemoryStorage extends StorageMechanism {
 
         this._valueStore = {};
 
-        this._setInitialValue(initialValue);
+        if(has('initialValue')(config)) {
+            this._setInitialValue(config.initialValue);
+        }
     }
 
     //

--- a/packages/react-cool-storage/src/MemoryStorage.js
+++ b/packages/react-cool-storage/src/MemoryStorage.js
@@ -21,7 +21,7 @@ class MemoryStorage extends StorageMechanism {
             updateFromProps: false
         });
 
-        this._valueStore = {};
+        this._valueStore = undefined;
 
         if(has('initialValue')(config)) {
             this._setInitialValue(config.initialValue);

--- a/packages/react-cool-storage/src/ReachRouterStorage.js
+++ b/packages/react-cool-storage/src/ReachRouterStorage.js
@@ -1,7 +1,7 @@
 // @flow
 import reduce from 'unmutable/reduce';
 import remove from 'unmutable/remove';
-import InvalidValueMarker from './InvalidValueMarker';
+import invalid from './invalid';
 import StorageMechanism from './StorageMechanism';
 import deepMemo from 'deep-memo';
 
@@ -63,7 +63,7 @@ class ReachRouterStorage extends StorageMechanism {
             try {
                 return JSON.parse(str);
             } catch(e) {
-                return InvalidValueMarker;
+                return invalid;
             }
         };
         this._defaultStringify = (data: any): string => JSON.stringify(data);

--- a/packages/react-cool-storage/src/ReachRouterStorage.js
+++ b/packages/react-cool-storage/src/ReachRouterStorage.js
@@ -34,7 +34,7 @@ class ReachRouterStorage extends StorageMechanism {
             stringify,
             deconstruct,
             reconstruct,
-            memoize = true
+            memoize = false
         } = config;
 
         const type = 'ReachRouterStorage';
@@ -51,6 +51,7 @@ class ReachRouterStorage extends StorageMechanism {
             deconstruct,
             reconstruct,
             requiresProps: true,
+            requiresKeyed: true,
             type,
             updateFromProps: true
         });

--- a/packages/react-cool-storage/src/ReactCoolStorageHook.jsx
+++ b/packages/react-cool-storage/src/ReactCoolStorageHook.jsx
@@ -9,7 +9,7 @@ import {useEffect} from 'react';
 // $FlowFixMe - react does export this
 import {useRef} from 'react';
 
-import InvalidValueMarker from './InvalidValueMarker';
+import invalid from './invalid';
 
 import ReactCoolStorageMessage from './ReactCoolStorageMessage';
 import last from 'unmutable/last';
@@ -67,7 +67,7 @@ export default (...storageMechanisms: StorageMechanism[]) => {
             ? options.value
             : storageMechanism.valueFromProps(props);
 
-        let valid = value !== InvalidValueMarker;
+        let valid = value !== invalid;
 
         return {
             available: true,

--- a/packages/react-cool-storage/src/ReactCoolStorageHook.jsx
+++ b/packages/react-cool-storage/src/ReactCoolStorageHook.jsx
@@ -82,7 +82,7 @@ export default (...storageMechanisms: StorageMechanism[]) => {
     // function component
     //
 
-    return (props: Props): ReactCoolStorageMessage => {
+    return (props: ?Props = {}): ReactCoolStorageMessage => {
 
         // use a ref as a component instance identifier in synchroniser
         const ref = useRef(null);

--- a/packages/react-cool-storage/src/ReactCoolStorageHook.jsx
+++ b/packages/react-cool-storage/src/ReactCoolStorageHook.jsx
@@ -12,7 +12,7 @@ import {useRef} from 'react';
 import InvalidValueMarker from './InvalidValueMarker';
 
 import ReactCoolStorageMessage from './ReactCoolStorageMessage';
-import last from 'unmutable/lib/last';
+import last from 'unmutable/last';
 
 type Props = {};
 

--- a/packages/react-cool-storage/src/ReactCoolStorageHook.jsx
+++ b/packages/react-cool-storage/src/ReactCoolStorageHook.jsx
@@ -100,7 +100,7 @@ export default (...storageMechanisms: StorageMechanism[]) => {
             return new ReactCoolStorageMessage({
                 ...ReactCoolStorageMessage.unavailable,
                 availabilityError,
-                onChange:  /* istanbul ignore next */ () => {}
+                set:  /* istanbul ignore next */ () => {}
             });
         }
 
@@ -148,8 +148,8 @@ export default (...storageMechanisms: StorageMechanism[]) => {
             storageMechanism._removeSyncListener(ref);
         }, []);
 
-        const onChange = (newValue: any) => {
-            let updatedValue = storageMechanism._onChangeWithOptions(
+        const set = (newValue: any) => {
+            let updatedValue = storageMechanism._setWithOptions(
                 newValue,
                 {
                     origin: ref,
@@ -168,7 +168,7 @@ export default (...storageMechanisms: StorageMechanism[]) => {
 
         return new ReactCoolStorageMessage({
             ...message,
-            onChange
+            set
         });
     };
 };

--- a/packages/react-cool-storage/src/ReactCoolStorageMessage.js
+++ b/packages/react-cool-storage/src/ReactCoolStorageMessage.js
@@ -1,11 +1,11 @@
 // @flow
 
-export type OnChange = (newValue: any) => void;
+export type SetFunction = (newValue: any) => void;
 
 export type ReactCoolStorageMessageConfig = {
     available: boolean,
     availabilityError: ?string,
-    onChange: OnChange,
+    set: SetFunction,
     storageType: string,
     valid: boolean,
     value: any
@@ -23,7 +23,7 @@ export default class ReactCoolStorageMessage {
 
     available: boolean;
     availabilityError: ?string;
-    onChange: OnChange;
+    set: SetFunction;
     storageType: string;
     valid: boolean;
     value: any;
@@ -31,7 +31,7 @@ export default class ReactCoolStorageMessage {
     constructor(config: ReactCoolStorageMessageConfig) {
         this.available = config.available;
         this.availabilityError = config.availabilityError;
-        this.onChange = config.onChange;
+        this.set = config.set;
         this.storageType = config.storageType;
         this.valid = config.valid;
         this.value = config.value;

--- a/packages/react-cool-storage/src/ReactRouterStorage.js
+++ b/packages/react-cool-storage/src/ReactRouterStorage.js
@@ -36,7 +36,7 @@ class ReactRouterStorage extends StorageMechanism {
             stringify,
             deconstruct,
             reconstruct,
-            memoize = true
+            memoize = false
         } = config;
 
         const type = 'ReactRouterStorage';
@@ -49,6 +49,7 @@ class ReactRouterStorage extends StorageMechanism {
             deconstruct,
             reconstruct,
             requiresProps: true,
+            requiresKeyed: true,
             type,
             updateFromProps: true
         });

--- a/packages/react-cool-storage/src/ReactRouterStorage.js
+++ b/packages/react-cool-storage/src/ReactRouterStorage.js
@@ -1,7 +1,7 @@
 // @flow
 import reduce from 'unmutable/reduce';
 import remove from 'unmutable/remove';
-import InvalidValueMarker from './InvalidValueMarker';
+import invalid from './invalid';
 import StorageMechanism from './StorageMechanism';
 import deepMemo from 'deep-memo';
 
@@ -60,7 +60,7 @@ class ReactRouterStorage extends StorageMechanism {
             try {
                 return JSON.parse(str);
             } catch(e) {
-                return InvalidValueMarker;
+                return invalid;
             }
         };
         this._defaultStringify = (data: any): string => JSON.stringify(data);

--- a/packages/react-cool-storage/src/StorageMechanism.js
+++ b/packages/react-cool-storage/src/StorageMechanism.js
@@ -59,7 +59,7 @@ export default class StorageMechanism {
         this._synchronizer && this._synchronizer.removeSyncListener(originToRemove);
     }
 
-    _onChangeWithOptions(newValue: any, {origin, props}: any = {}): any {
+    _setWithOptions(newValue: any, {origin, props}: any = {}): any {
 
         // if _availableFromProps returns an error string, quit
         if(this._availableFromProps(props)) {
@@ -79,7 +79,7 @@ export default class StorageMechanism {
             );
 
         if(this._requiresKeyed && !isKeyed(updatedValue)) {
-            throw new Error(`${this.storageType} onChange must be passed an object`);
+            throw new Error(`${this.storageType} set must be passed an object`);
         }
 
         if(this._requiresKeyed) {
@@ -164,11 +164,11 @@ export default class StorageMechanism {
         return this.valueFromProps();
     }
 
-    onChange(newValue: any): void {
+    set(newValue: any): void {
         if(this._requiresProps) {
             throw new Error(this._requiresPropsErrorMessage);
         }
-        this._onChangeWithOptions(newValue);
+        this._setWithOptions(newValue);
     }
 
     valueFromProps(props: any): any {

--- a/packages/react-cool-storage/src/StorageMechanism.js
+++ b/packages/react-cool-storage/src/StorageMechanism.js
@@ -1,9 +1,6 @@
 // @flow
 import filter from 'unmutable/filter';
-import keyArray from 'unmutable/keyArray';
 import isKeyed from 'unmutable/isKeyed';
-import merge from 'unmutable/merge';
-import omit from 'unmutable/omit';
 import pipeWith from 'unmutable/pipeWith';
 
 import InvalidValueMarker from './InvalidValueMarker';
@@ -13,6 +10,7 @@ type Config = {
     deconstruct?: Function,
     reconstruct?: Function,
     requiresProps: boolean,
+    requiresKeyed: boolean,
     synchronizer?: Synchronizer,
     type: string,
     updateFromProps: boolean
@@ -30,6 +28,7 @@ export default class StorageMechanism {
         this._deconstruct = config.deconstruct || passthrough;
         this._reconstruct = config.reconstruct || passthrough;
         this._requiresProps = config.requiresProps;
+        this._requiresKeyed = config.requiresKeyed;
         this._synchronizer = config.synchronizer;
         this._type = config.type;
         this._updateFromProps = config.updateFromProps;
@@ -44,6 +43,7 @@ export default class StorageMechanism {
     _props: any;
     _reconstruct: Function;
     _requiresProps: boolean;
+    _requiresKeyed: boolean;
     _synchronizer: ?Synchronizer;
     _type: string;
     _updateFromProps: boolean;
@@ -61,39 +61,33 @@ export default class StorageMechanism {
 
     _onChangeWithOptions(newValue: any, {origin, props}: any = {}): any {
 
-        newValue = this._deconstruct(newValue);
-
-        if(!isKeyed(newValue)) {
-            throw new Error(`${this._type} onChange must be passed an object`);
+        // if _availableFromProps returns an error string, quit
+        if(this._availableFromProps(props)) {
+            return;
         }
 
-        let value = this.valueFromProps(props);
-        let valueIsInvalid = value === InvalidValueMarker;
-
-        let removedKeys = valueIsInvalid
-            ? []
+        let updatedValue = typeof newValue === 'function'
+            ? pipeWith(
+                this._valueFromProps(props),
+                this._reconstruct,
+                newValue,
+                this._deconstruct
+            )
             : pipeWith(
                 newValue,
-                filter(_ => typeof _ === "undefined"),
-                keyArray()
+                this._deconstruct
             );
 
-        let changedValues = valueIsInvalid
-            ? newValue
-            : omit(removedKeys)(newValue);
+        if(this._requiresKeyed && !isKeyed(updatedValue)) {
+            throw new Error(`${this.storageType} onChange must be passed an object`);
+        }
 
-        let updatedValue = valueIsInvalid
-            ? newValue
-            : pipeWith(
-                props ? value : this.value,
-                merge(changedValues),
-                omit(removedKeys)
-            );
+        if(this._requiresKeyed) {
+            updatedValue = filter(value => value !== undefined)(updatedValue);
+        }
 
         this._handleChange({
             updatedValue,
-            changedValues,
-            removedKeys,
             props,
             origin
         });
@@ -102,20 +96,27 @@ export default class StorageMechanism {
     }
 
     _setInitialValue(initialValue: any) {
-        if(typeof initialValue === "function") {
-            initialValue = initialValue(this.value);
+
+        // if _availableFromProps returns an error string, quit
+        if(this._availableFromProps()) {
+            return;
         }
 
-        if(initialValue) {
-            if(!isKeyed(initialValue)) {
-                throw new Error(`${this.storageType} initialValue must be passed an object`);
-            }
+        let updatedValue = typeof initialValue === 'function'
+            ? initialValue(this.value)
+            : initialValue;
 
-            this._handleChange({
-                updatedValue: initialValue,
-                origin: this
-            });
-        }
+        // we dont have any storage mechanisms that need to be keyed and also allow initialValues
+        // but if we do then we'll need this:
+
+        // if(this._requiresKeyed && !isKeyed(updatedValue)) {
+        //     throw new Error(`${this.storageType} initialValue must be passed an object`);
+        // }
+
+        this._handleChange({
+            updatedValue,
+            origin: this
+        });
     }
 
     //
@@ -135,7 +136,7 @@ export default class StorageMechanism {
     }
 
     //
-    // public
+    // public for when the storage mechanism is used outside of react
     //
 
     get available(): ?boolean {

--- a/packages/react-cool-storage/src/StorageMechanism.js
+++ b/packages/react-cool-storage/src/StorageMechanism.js
@@ -3,7 +3,7 @@ import filter from 'unmutable/filter';
 import isKeyed from 'unmutable/isKeyed';
 import pipeWith from 'unmutable/pipeWith';
 
-import InvalidValueMarker from './InvalidValueMarker';
+import invalid from './invalid';
 import Synchronizer from './Synchronizer';
 
 type Config = {
@@ -150,7 +150,7 @@ export default class StorageMechanism {
     }
 
     get valid(): boolean {
-        return this.value !== InvalidValueMarker;
+        return this.value !== invalid;
     }
 
     get storageType(): any {

--- a/packages/react-cool-storage/src/StorageMechanism.js
+++ b/packages/react-cool-storage/src/StorageMechanism.js
@@ -1,11 +1,10 @@
 // @flow
-import filter from 'unmutable/lib/filter';
-import identity from 'unmutable/identity';
-import keyArray from 'unmutable/lib/keyArray';
-import isKeyed from 'unmutable/lib/isKeyed';
-import merge from 'unmutable/lib/merge';
-import omit from 'unmutable/lib/omit';
-import pipeWith from 'unmutable/lib/pipeWith';
+import filter from 'unmutable/filter';
+import keyArray from 'unmutable/keyArray';
+import isKeyed from 'unmutable/isKeyed';
+import merge from 'unmutable/merge';
+import omit from 'unmutable/omit';
+import pipeWith from 'unmutable/pipeWith';
 
 import InvalidValueMarker from './InvalidValueMarker';
 import Synchronizer from './Synchronizer';
@@ -27,8 +26,9 @@ type SyncListener = {
 export default class StorageMechanism {
 
     constructor(config: Config) {
-        this._deconstruct = config.deconstruct || identity();
-        this._reconstruct = config.reconstruct || identity();
+        let passthrough = ii => ii;
+        this._deconstruct = config.deconstruct || passthrough;
+        this._reconstruct = config.reconstruct || passthrough;
         this._requiresProps = config.requiresProps;
         this._synchronizer = config.synchronizer;
         this._type = config.type;

--- a/packages/react-cool-storage/src/WebStorage.js
+++ b/packages/react-cool-storage/src/WebStorage.js
@@ -1,5 +1,6 @@
 // @flow
 import storageAvailable from 'storage-available';
+import has from 'unmutable/has';
 import pipeWith from 'unmutable/pipeWith';
 import InvalidValueMarker from './InvalidValueMarker';
 import StorageMechanism from './StorageMechanism';
@@ -29,7 +30,7 @@ class WebStorage extends StorageMechanism {
             stringify = (data: any): string => JSON.stringify(data),
             deconstruct,
             reconstruct,
-            memoize = true,
+            memoize = false,
             initialValue
         } = config || {};
 
@@ -51,6 +52,7 @@ class WebStorage extends StorageMechanism {
             deconstruct,
             reconstruct,
             requiresProps: false,
+            requiresKeyed: false,
             synchronizer: synchronizerMap[key],
             type,
             updateFromProps: false
@@ -71,7 +73,9 @@ class WebStorage extends StorageMechanism {
             this._parse = deepMemo(this._parse);
         }
 
-        this._setInitialValue(initialValue);
+        if(has('initialValue')(config)) {
+            this._setInitialValue(initialValue);
+        }
     }
 
     //
@@ -84,7 +88,7 @@ class WebStorage extends StorageMechanism {
     _stringify: (data: any) => string;
 
     _stringFromProps = (props: any /* eslint-disable-line */): string => {
-        let storage = typeof window !== "undefined" && window[this._method];
+        let storage = window !== undefined && window[this._method];
         if(!storage) {
             return "";
         }

--- a/packages/react-cool-storage/src/WebStorage.js
+++ b/packages/react-cool-storage/src/WebStorage.js
@@ -2,7 +2,7 @@
 import storageAvailable from 'storage-available';
 import has from 'unmutable/has';
 import pipeWith from 'unmutable/pipeWith';
-import InvalidValueMarker from './InvalidValueMarker';
+import invalid from './invalid';
 import StorageMechanism from './StorageMechanism';
 import Synchronizer from './Synchronizer';
 import deepMemo from 'deep-memo';
@@ -62,9 +62,9 @@ class WebStorage extends StorageMechanism {
         this._method = method;
         this._parse = (str) => {
             try {
-                return parse(str) || {};
+                return parse(str);
             } catch(e) {
-                return InvalidValueMarker;
+                return invalid;
             }
         };
         this._stringify = stringify;

--- a/packages/react-cool-storage/src/__test__/MemoryStorage-test.js
+++ b/packages/react-cool-storage/src/__test__/MemoryStorage-test.js
@@ -28,23 +28,22 @@ describe('MemoryStorage storage mechanism tests', () => {
 
 describe('Behaviour tests that should apply to all storage mechanisms', () => {
 
-    test('MemoryStorage value should merge', () => {
+    test('MemoryStorage onChange should accept new value', () => {
+        const MyMemoryStorage = MemoryStorage();
+        MyMemoryStorage.onChange(100);
+        expect(MyMemoryStorage.value).toBe(100);
+    });
+
+    test('MemoryStorage onChange should accept new keyed value', () => {
+        let updater = jest.fn((prev) => ({...prev, def: 300, ghi: 400}));
+
         const MyMemoryStorage = MemoryStorage();
         MyMemoryStorage.onChange({abc: 100, def: 200});
-        MyMemoryStorage.onChange({def: 300, ghi: 400});
+        MyMemoryStorage.onChange(updater);
+
+        expect(updater).toHaveBeenCalledTimes(1);
+        expect(updater.mock.calls[0][0]).toEqual({abc: 100, def: 200});
         expect(MyMemoryStorage.value).toEqual({abc: 100, def: 300, ghi: 400});
-    });
-
-    test('MemoryStorage value should delete keys set to undefined', () => {
-        const MyMemoryStorage = MemoryStorage();
-        MyMemoryStorage.onChange({abc: 100, def: 200});
-        MyMemoryStorage.onChange({abc: undefined});
-        expect(MyMemoryStorage.value).toEqual({def: 200});
-    });
-
-    test('MemoryStorage onChange should throw error if given non object', () => {
-        const MyMemoryStorage = MemoryStorage();
-        expect(() => MyMemoryStorage.onChange(123)).toThrowError(`MemoryStorage onChange must be passed an object`);
     });
 
 });
@@ -61,6 +60,14 @@ describe('MemoryStorage data flow config tests', () => {
         expect(MyMemoryStorage.value).toEqual({def: 600});
     });
 
+    test('MemoryStorage should accept non-keyed initialValue', () => {
+        const MyMemoryStorage = MemoryStorage({
+            initialValue: 600
+        });
+
+        expect(MyMemoryStorage.value).toEqual(600);
+    });
+
     test('MemoryStorage should set initialValue as function', () => {
         let initialValue = jest.fn(() => ({def: 200}));
 
@@ -69,18 +76,6 @@ describe('MemoryStorage data flow config tests', () => {
         expect(MyMemoryStorage.value).toEqual({def: 200});
         expect(initialValue.mock.calls[0][0]).toEqual({});
     });
-
-    test('MemoryStorage should not set initialValue if function returns falsey', () => {
-
-        const MyMemoryStorage = MemoryStorage({initialValue: () => false});
-
-        expect(MyMemoryStorage.value).toEqual({});
-    });
-
-    test('MemoryStorage should throw error if initialValue is not keyed', () => {
-        expect(() => MemoryStorage({initialValue: 600})).toThrowError(`MemoryStorage initialValue must be passed an object`);
-    });
-
 });
 
 describe('Hook tests', () => {

--- a/packages/react-cool-storage/src/__test__/MemoryStorage-test.js
+++ b/packages/react-cool-storage/src/__test__/MemoryStorage-test.js
@@ -20,7 +20,7 @@ describe('MemoryStorage storage mechanism tests', () => {
 
     test('MemoryStorage value should be set and get', () => {
         const MyMemoryStorage = MemoryStorage();
-        MyMemoryStorage.onChange({abc: 100});
+        MyMemoryStorage.set({abc: 100});
         expect(MyMemoryStorage.value).toEqual({abc: 100});
     });
 
@@ -28,18 +28,18 @@ describe('MemoryStorage storage mechanism tests', () => {
 
 describe('Behaviour tests that should apply to all storage mechanisms', () => {
 
-    test('MemoryStorage onChange should accept new value', () => {
+    test('MemoryStorage set should accept new value', () => {
         const MyMemoryStorage = MemoryStorage();
-        MyMemoryStorage.onChange(100);
+        MyMemoryStorage.set(100);
         expect(MyMemoryStorage.value).toBe(100);
     });
 
-    test('MemoryStorage onChange should accept new keyed value', () => {
+    test('MemoryStorage set should accept new keyed value', () => {
         let updater = jest.fn((prev) => ({...prev, def: 300, ghi: 400}));
 
         const MyMemoryStorage = MemoryStorage();
-        MyMemoryStorage.onChange({abc: 100, def: 200});
-        MyMemoryStorage.onChange(updater);
+        MyMemoryStorage.set({abc: 100, def: 200});
+        MyMemoryStorage.set(updater);
 
         expect(updater).toHaveBeenCalledTimes(1);
         expect(updater.mock.calls[0][0]).toEqual({abc: 100, def: 200});
@@ -97,7 +97,7 @@ describe('Hook tests', () => {
         const {result} = renderHook(() => useStorage({}));
 
         act(() => {
-            result.current.onChange({abc: 123});
+            result.current.set({abc: 123});
         });
 
         expect(result.current.value).toEqual({abc: 123});
@@ -109,7 +109,7 @@ describe('Hook tests', () => {
         const {result} = renderHook(() => useStorage({}));
 
         act(() => {
-            MyMemoryStorage.onChange({abc: 123});
+            MyMemoryStorage.set({abc: 123});
         });
 
         expect(result.current.value).toEqual({abc: 123});
@@ -150,7 +150,7 @@ describe('Hoc tests', () => {
         const {result, act} = renderHoc(hoc, {});
 
         act(() => {
-            result.current.foo.onChange({abc: 123});
+            result.current.foo.set({abc: 123});
         });
 
         expect(result.current.foo.value).toEqual({abc: 123});
@@ -162,7 +162,7 @@ describe('Hoc tests', () => {
         const {result, act} = renderHoc(hoc, {});
 
         act(() => {
-            MyMemoryStorage.onChange({abc: 123});
+            MyMemoryStorage.set({abc: 123});
         });
 
         expect(result.current.foo.value).toEqual({abc: 123});

--- a/packages/react-cool-storage/src/__test__/MemoryStorage-test.js
+++ b/packages/react-cool-storage/src/__test__/MemoryStorage-test.js
@@ -15,7 +15,7 @@ describe('MemoryStorage storage mechanism tests', () => {
         expect(MyMemoryStorage.availabilityError).toBe(undefined);
         expect(MyMemoryStorage.valid).toBe(true);
         expect(MyMemoryStorage.storageType).toBe("MemoryStorage");
-        expect(MyMemoryStorage.value).toEqual({});
+        expect(MyMemoryStorage.value).toEqual(undefined);
     });
 
     test('MemoryStorage value should be set and get', () => {
@@ -74,7 +74,7 @@ describe('MemoryStorage data flow config tests', () => {
         const MyMemoryStorage = MemoryStorage({initialValue});
 
         expect(MyMemoryStorage.value).toEqual({def: 200});
-        expect(initialValue.mock.calls[0][0]).toEqual({});
+        expect(initialValue.mock.calls[0][0]).toEqual(undefined);
     });
 });
 
@@ -82,19 +82,19 @@ describe('Hook tests', () => {
 
     test('MemoryStorage hook should work', () => {
         const useStorage = ReactCoolStorageHook(MemoryStorage());
-        const {result} = renderHook(() => useStorage({}));
+        const {result} = renderHook(() => useStorage());
         const memoryStorage = result.current;
 
         expect(memoryStorage.available).toBe(true);
         expect(memoryStorage.availabilityError).toBe(undefined);
         expect(memoryStorage.storageType).toBe("MemoryStorage");
         expect(memoryStorage.valid).toBe(true);
-        expect(memoryStorage.value).toEqual({});
+        expect(memoryStorage.value).toEqual(undefined);
     });
 
     test('MemoryStorage hook should change', () => {
         const useStorage = ReactCoolStorageHook(MemoryStorage());
-        const {result} = renderHook(() => useStorage({}));
+        const {result} = renderHook(() => useStorage());
 
         act(() => {
             result.current.set({abc: 123});
@@ -106,7 +106,7 @@ describe('Hook tests', () => {
     test('MemoryStorage hook should rerender based on change directly from MemoryStorage instance', () => {
         const MyMemoryStorage = MemoryStorage();
         const useStorage = ReactCoolStorageHook(MyMemoryStorage);
-        const {result} = renderHook(() => useStorage({}));
+        const {result} = renderHook(() => useStorage());
 
         act(() => {
             MyMemoryStorage.set({abc: 123});
@@ -118,7 +118,7 @@ describe('Hook tests', () => {
     test('MemoryStorage hook should unmount and remove sync listeners', () => {
         const MyMemoryStorage = MemoryStorage();
         const useStorage = ReactCoolStorageHook(MyMemoryStorage);
-        const {unmount} = renderHook(() => useStorage({}));
+        const {unmount} = renderHook(() => useStorage());
 
         expect(MyMemoryStorage._synchronizer.syncListeners.length).toBe(1);
 
@@ -142,7 +142,7 @@ describe('Hoc tests', () => {
         expect(memoryStorage.availabilityError).toBe(undefined);
         expect(memoryStorage.storageType).toBe("MemoryStorage");
         expect(memoryStorage.valid).toBe(true);
-        expect(memoryStorage.value).toEqual({});
+        expect(memoryStorage.value).toEqual(undefined);
     });
 
     test('MemoryStorage hoc should change', () => {

--- a/packages/react-cool-storage/src/__test__/ReachRouterStorage-test.js
+++ b/packages/react-cool-storage/src/__test__/ReachRouterStorage-test.js
@@ -34,7 +34,7 @@ describe('ReachRouterStorage storage mechanism tests', () => {
         const MyReachRouterStorage = ReachRouterStorage({navigate});
 
         expect(() => MyReachRouterStorage.value).toThrow(`ReachRouterStorage requires props and cannot be used outside of React`);
-        expect(() => MyReachRouterStorage.onChange({})).toThrow(`ReachRouterStorage requires props and cannot be used outside of React`);
+        expect(() => MyReachRouterStorage.set({})).toThrow(`ReachRouterStorage requires props and cannot be used outside of React`);
 
     });
 
@@ -97,7 +97,7 @@ describe('ReachRouterStorage storage mechanism tests', () => {
         }));
 
         act(() => {
-            result.current.onChange({abc: 200});
+            result.current.set({abc: 200});
         });
 
         expect(navigate).toHaveBeenCalled();
@@ -105,7 +105,7 @@ describe('ReachRouterStorage storage mechanism tests', () => {
         expect(navigate.mock.calls[0][1]).toEqual({replace: false});
     });
 
-    test('ReachRouterStorage onChange should throw error if given non object', () => {
+    test('ReachRouterStorage set should throw error if given non object', () => {
         const useStorage = ReactCoolStorageHook(ReachRouterStorage({navigate}));
         const {result} = renderHook(() => useStorage({
             location: {
@@ -114,7 +114,7 @@ describe('ReachRouterStorage storage mechanism tests', () => {
             }
         }));
 
-        expect(() => result.current.onChange(123)).toThrowError(`ReachRouterStorage onChange must be passed an object`);
+        expect(() => result.current.set(123)).toThrowError(`ReachRouterStorage set must be passed an object`);
     });
 
     test('ReachRouterStorage should write query string with replace: true', () => {
@@ -133,7 +133,7 @@ describe('ReachRouterStorage storage mechanism tests', () => {
         }));
 
         act(() => {
-            result.current.onChange({abc: 200});
+            result.current.set({abc: 200});
         });
 
         expect(navigate).toHaveBeenCalled();
@@ -153,7 +153,7 @@ describe('ReachRouterStorage storage mechanism tests', () => {
         }));
 
         act(() => {
-            result.current.onChange({abc: undefined, def: 200});
+            result.current.set({abc: undefined, def: 200});
         });
 
         expect(navigate.mock.calls[0][0]).toBe("/abc?def=200");
@@ -191,7 +191,7 @@ describe('ReachRouterStorage storage mechanism tests', () => {
         expect(result.current.value).toEqual({pathname: "/abc", abc: 100});
 
         act(() => {
-            result.current.onChange({abc: 200, pathname: "/flee"});
+            result.current.set({abc: 200, pathname: "/flee"});
         });
 
         expect(navigate.mock.calls[0][0]).toBe("/flee?abc=200");
@@ -222,7 +222,7 @@ describe('ReachRouterStorage data flow config tests', () => {
         expect(result.current.value.date.toISOString()).toBe("1970-01-01T00:00:00.000Z");
 
         act(() => {
-            result.current.onChange({date: new Date('2000-01-01')});
+            result.current.set({date: new Date('2000-01-01')});
         });
 
         expect(navigate.mock.calls[0][0]).toBe(`/abc?date=%222000-01-01T00%3A00%3A00.000Z%22`);
@@ -251,7 +251,7 @@ describe('ReachRouterStorage data flow config tests', () => {
         expect(result.current.value).toEqual({abc: 123});
 
         act(() => {
-            result.current.onChange({abc: 456});
+            result.current.set({abc: 456});
         });
 
         expect(navigate.mock.calls[0][0]).toBe(`/abc?foo{"abc":456}`);
@@ -284,7 +284,7 @@ describe('ReachRouterStorage memoization tests', () => {
         const value1 = result.current.value;
 
         act(() => {
-            result.current.onChange({abc: 100});
+            result.current.set({abc: 100});
             let url = navigate.mock.calls[0][0];
 
             rerender({
@@ -322,7 +322,7 @@ describe('ReachRouterStorage memoization tests', () => {
         const value1 = result.current.value;
 
         act(() => {
-            result.current.onChange({abc: 100});
+            result.current.set({abc: 100});
             let url = navigate.mock.calls[0][0];
 
             rerender({
@@ -360,7 +360,7 @@ describe('ReachRouterStorage memoization tests', () => {
         const value1 = result.current.value;
 
         act(() => {
-            result.current.onChange((prev) => ({
+            result.current.set((prev) => ({
                 ...prev,
                 abc: [400, 200]
             }));

--- a/packages/react-cool-storage/src/__test__/ReachRouterStorage-test.js
+++ b/packages/react-cool-storage/src/__test__/ReachRouterStorage-test.js
@@ -1,7 +1,7 @@
 // @flow
 import ReactCoolStorageHook from '../ReactCoolStorageHook';
 import ReachRouterStorage from '../ReachRouterStorage';
-import InvalidValueMarker from '../InvalidValueMarker';
+import invalid from '../invalid';
 
 import {act} from 'react-hooks-testing-library';
 import {renderHook} from 'react-hooks-testing-library';
@@ -172,7 +172,7 @@ describe('ReachRouterStorage storage mechanism tests', () => {
         expect(result.current.available).toBe(true);
         expect(result.current.availabilityError).toBe(undefined);
         expect(result.current.valid).toBe(false);
-        expect(result.current.value).toBe(InvalidValueMarker);
+        expect(result.current.value).toBe(invalid);
     });
 
     test('ReactRouterStorage should write pathname', () => {

--- a/packages/react-cool-storage/src/__test__/ReactRouterStorage-test.js
+++ b/packages/react-cool-storage/src/__test__/ReactRouterStorage-test.js
@@ -29,7 +29,7 @@ describe('ReactRouterStorage storage mechanism tests', () => {
         const MyReactRouterStorage = ReactRouterStorage();
 
         expect(() => MyReactRouterStorage.value).toThrow(`ReactRouterStorage requires props and cannot be used outside of React`);
-        expect(() => MyReactRouterStorage.onChange({})).toThrow(`ReactRouterStorage requires props and cannot be used outside of React`);
+        expect(() => MyReactRouterStorage.set({})).toThrow(`ReactRouterStorage requires props and cannot be used outside of React`);
 
     });
 
@@ -109,7 +109,7 @@ describe('ReactRouterStorage storage mechanism tests', () => {
         }));
 
         act(() => {
-            result.current.onChange({abc: 200});
+            result.current.set({abc: 200});
         });
 
         expect(history.push).toHaveBeenCalled();
@@ -117,7 +117,7 @@ describe('ReactRouterStorage storage mechanism tests', () => {
         expect(history.push.mock.calls[0][0]).toBe("?abc=200");
     });
 
-    test('ReactRouterStorage onChange should throw error if given non object', () => {
+    test('ReactRouterStorage set should throw error if given non object', () => {
         const useStorage = ReactCoolStorageHook(ReactRouterStorage());
         const {result} = renderHook(() => useStorage({
             location: {
@@ -127,7 +127,7 @@ describe('ReactRouterStorage storage mechanism tests', () => {
             history
         }));
 
-        expect(() => result.current.onChange(123)).toThrowError(`ReactRouterStorage onChange must be passed an object`);
+        expect(() => result.current.set(123)).toThrowError(`ReactRouterStorage set must be passed an object`);
     });
 
     test('ReactRouterStorage should write query string with replace: true', () => {
@@ -150,7 +150,7 @@ describe('ReactRouterStorage storage mechanism tests', () => {
         }));
 
         act(() => {
-            result.current.onChange({abc: 200});
+            result.current.set({abc: 200});
         });
 
         expect(history.push).not.toHaveBeenCalled();
@@ -175,7 +175,7 @@ describe('ReactRouterStorage storage mechanism tests', () => {
         }));
 
         act(() => {
-            result.current.onChange({abc: undefined, def: 200});
+            result.current.set({abc: undefined, def: 200});
         });
 
         expect(history.push.mock.calls[0][0]).toBe("?def=200");
@@ -217,7 +217,7 @@ describe('ReactRouterStorage storage mechanism tests', () => {
         expect(result.current.value).toEqual({pathname: "/abc", abc: 100});
 
         act(() => {
-            result.current.onChange({abc: 200, pathname: "/flee"});
+            result.current.set({abc: 200, pathname: "/flee"});
         });
 
         expect(history.push).toHaveBeenCalled();
@@ -252,7 +252,7 @@ describe('ReactRouterStorage data flow config tests', () => {
         expect(result.current.value.date.toISOString()).toBe("1970-01-01T00:00:00.000Z");
 
         act(() => {
-            result.current.onChange({date: new Date('2000-01-01')});
+            result.current.set({date: new Date('2000-01-01')});
         });
 
         expect(history.push.mock.calls[0][0]).toBe(`?date=%222000-01-01T00%3A00%3A00.000Z%22`);
@@ -285,7 +285,7 @@ describe('ReactRouterStorage data flow config tests', () => {
         expect(result.current.value).toEqual({abc: 123});
 
         act(() => {
-            result.current.onChange({abc: 456});
+            result.current.set({abc: 456});
         });
 
         expect(history.push.mock.calls[0][0]).toBe(`?foo{"abc":456}`);
@@ -322,7 +322,7 @@ describe('ReactRouterStorage memoization tests', () => {
         const value1 = result.current.value;
 
         act(() => {
-            result.current.onChange({abc: 100});
+            result.current.set({abc: 100});
             let search = history.push.mock.calls[0][0];
 
             rerender({
@@ -364,7 +364,7 @@ describe('ReactRouterStorage memoization tests', () => {
         const value1 = result.current.value;
 
         act(() => {
-            result.current.onChange({abc: 100});
+            result.current.set({abc: 100});
             let search = history.push.mock.calls[0][0];
 
             rerender({
@@ -407,7 +407,7 @@ describe('ReactRouterStorage memoization tests', () => {
         const value1 = result.current.value;
 
         act(() => {
-            result.current.onChange((prev) => ({
+            result.current.set((prev) => ({
                 ...prev,
                 abc: [400, 200]
             }));

--- a/packages/react-cool-storage/src/__test__/ReactRouterStorage-test.js
+++ b/packages/react-cool-storage/src/__test__/ReactRouterStorage-test.js
@@ -1,7 +1,7 @@
 // @flow
 import ReactCoolStorageHook from '../ReactCoolStorageHook';
 import ReactRouterStorage from '../ReactRouterStorage';
-import InvalidValueMarker from '../InvalidValueMarker';
+import invalid from '../invalid';
 
 import {act} from 'react-hooks-testing-library';
 import {renderHook} from 'react-hooks-testing-library';
@@ -195,7 +195,7 @@ describe('ReactRouterStorage storage mechanism tests', () => {
         expect(result.current.available).toBe(true);
         expect(result.current.availabilityError).toBe(undefined);
         expect(result.current.valid).toBe(false);
-        expect(result.current.value).toBe(InvalidValueMarker);
+        expect(result.current.value).toBe(invalid);
     });
 
     test('ReactRouterStorage should write pathname', () => {

--- a/packages/react-cool-storage/src/__test__/WebStorage-test.js
+++ b/packages/react-cool-storage/src/__test__/WebStorage-test.js
@@ -46,7 +46,7 @@ describe('WebStorage storage mechanism tests', () => {
         let temp = window.localStorage;
         delete window.localStorage;
 
-        expect(() => WebStorage({key: "localStorageKey"}).onChange({abc: 123})).not.toThrow();
+        expect(() => WebStorage({key: "localStorageKey"}).set({abc: 123})).not.toThrow();
 
         window.localStorage = temp;
     });
@@ -69,7 +69,7 @@ describe('WebStorage storage mechanism tests', () => {
         window.localStorage.setItem("localStorageKey", `{"abc":123}`);
 
         const MyWebStorage = WebStorage({key: "localStorageKey"});
-        MyWebStorage.onChange({abc: 100});
+        MyWebStorage.set({abc: 100});
         expect(localStorage.getItem("localStorageKey")).toEqual(`{"abc":100}`);
     });
 
@@ -94,7 +94,7 @@ describe('WebStorage storage mechanism tests', () => {
             key: "sessionStorageKey",
             method: "sessionStorage"
         });
-        MyWebStorage.onChange({def: 100});
+        MyWebStorage.set({def: 100});
         expect(sessionStorage.getItem("sessionStorageKey")).toEqual(`{"def":100}`);
     });
 
@@ -127,7 +127,7 @@ describe('WebStorage storage mechanism tests', () => {
 
         expect(MyWebStorage.valid).toBe(false);
 
-        MyWebStorage.onChange({abc: 123});
+        MyWebStorage.set({abc: 123});
         expect(MyWebStorage.valid).toBe(true);
         expect(MyWebStorage.value).toEqual({abc: 123});
     });
@@ -147,7 +147,7 @@ describe('WebStorage data flow config tests', () => {
 
         expect(MyWebStorage.value.date.toISOString()).toBe("1970-01-01T00:00:00.000Z");
 
-        MyWebStorage.onChange({date: new Date('2000-01-01')});
+        MyWebStorage.set({date: new Date('2000-01-01')});
 
         expect(localStorage.getItem("localStorageKey")).toBe(`{"date":"2000-01-01T00:00:00.000Z"}`);
     });
@@ -163,7 +163,7 @@ describe('WebStorage data flow config tests', () => {
 
         expect(MyWebStorage.value).toEqual({abc:123});
 
-        MyWebStorage.onChange({abc: 456});
+        MyWebStorage.set({abc: 456});
 
         expect(localStorage.getItem("localStorageKey")).toBe(`foo{"abc":456}`);
     });
@@ -222,7 +222,7 @@ describe('WebStorage memoization tests', () => {
         });
 
         const value1 = MyWebStorage.value;
-        MyWebStorage.onChange({abc: 100});
+        MyWebStorage.set({abc: 100});
         const value2 = MyWebStorage.value;
 
         expect(value1).toEqual(value2);
@@ -238,7 +238,7 @@ describe('WebStorage memoization tests', () => {
         });
 
         const value1 = MyWebStorage.value;
-        MyWebStorage.onChange({abc: [400,200],def:300});
+        MyWebStorage.set({abc: [400,200],def:300});
         const value2 = MyWebStorage.value;
 
         expect(value1).not.toBe(value2);
@@ -273,7 +273,7 @@ describe('Hook tests', () => {
         const {result} = renderHook(() => useStorage({}));
 
         act(() => {
-            result.current.onChange({abc: 200});
+            result.current.set({abc: 200});
         });
 
         expect(result.current.value).toEqual({abc: 200});
@@ -288,7 +288,7 @@ describe('Hook tests', () => {
         const {result} = renderHook(() => useStorage({}));
 
         act(() => {
-            MyWebStorage.onChange({abc: 200});
+            MyWebStorage.set({abc: 200});
         });
 
         expect(result.current.value).toEqual({abc: 200});

--- a/packages/react-cool-storage/src/__test__/WebStorage-test.js
+++ b/packages/react-cool-storage/src/__test__/WebStorage-test.js
@@ -2,7 +2,7 @@
 import ReactCoolStorageHook from '../ReactCoolStorageHook';
 import ReactCoolStorageHoc from '../ReactCoolStorageHoc';
 import WebStorage from '../WebStorage';
-import InvalidValueMarker from '../InvalidValueMarker';
+import invalid from '../invalid';
 
 import {act} from 'react-hooks-testing-library';
 import {renderHook} from 'react-hooks-testing-library';
@@ -37,7 +37,7 @@ describe('WebStorage storage mechanism tests', () => {
         expect(MyWebStorage.availabilityError).toBe(`WebStorage requires localStorage to be available`);
         expect(MyWebStorage.valid).toBe(false);
         expect(MyWebStorage.storageType).toBe("WebStorage");
-        expect(MyWebStorage.value).toBe(InvalidValueMarker);
+        expect(MyWebStorage.value).toBe(invalid);
 
         window.localStorage = temp;
     });
@@ -117,7 +117,7 @@ describe('WebStorage storage mechanism tests', () => {
         expect(MyWebStorage.available).toBe(true);
         expect(MyWebStorage.availabilityError).toBe(undefined);
         expect(MyWebStorage.valid).toBe(false);
-        expect(MyWebStorage.value).toBe(InvalidValueMarker);
+        expect(MyWebStorage.value).toBe(invalid);
     });
 
     test('WebStorage should be able to change after invalid data', () => {

--- a/packages/react-cool-storage/src/__test__/WebStorage-test.js
+++ b/packages/react-cool-storage/src/__test__/WebStorage-test.js
@@ -106,7 +106,7 @@ describe('WebStorage storage mechanism tests', () => {
         expect(MyWebStorage.available).toBe(true);
         expect(MyWebStorage.availabilityError).toBe(undefined);
         expect(MyWebStorage.valid).toBe(true);
-        expect(MyWebStorage.value).toEqual({});
+        expect(MyWebStorage.value).toEqual(null);
     });
 
     test('WebStorage should notify of invalid data', () => {
@@ -256,7 +256,7 @@ describe('Hook tests', () => {
         window.localStorage.setItem("localStorageKey", `{"abc":100}`);
 
         const useStorage = ReactCoolStorageHook(WebStorage({key: "localStorageKey"}));
-        const {result} = renderHook(() => useStorage({}));
+        const {result} = renderHook(() => useStorage());
         const memoryStorage = result.current;
 
         expect(memoryStorage.available).toBe(true);
@@ -270,7 +270,7 @@ describe('Hook tests', () => {
         window.localStorage.setItem("localStorageKey", `{"abc":100}`);
 
         const useStorage = ReactCoolStorageHook(WebStorage({key: "localStorageKey"}));
-        const {result} = renderHook(() => useStorage({}));
+        const {result} = renderHook(() => useStorage());
 
         act(() => {
             result.current.set({abc: 200});
@@ -285,7 +285,7 @@ describe('Hook tests', () => {
         window.localStorage.setItem("localStorageKey", `{"abc":100}`);
         const MyWebStorage = WebStorage({key: "localStorageKey"});
         const useStorage = ReactCoolStorageHook(MyWebStorage);
-        const {result} = renderHook(() => useStorage({}));
+        const {result} = renderHook(() => useStorage());
 
         act(() => {
             MyWebStorage.set({abc: 200});

--- a/packages/react-cool-storage/src/invalid.js
+++ b/packages/react-cool-storage/src/invalid.js
@@ -1,0 +1,4 @@
+// @flow
+
+const INVALID_VALUE_MARKER = Symbol('INVALID_VALUE');
+export default INVALID_VALUE_MARKER;


### PR DESCRIPTION
- Added ability for `onChange()` to accept a function that gives the current value, and sets the returned value
- **BREAKING CHANGE**: make keyed objects optional
  - Only reach router and react router require objects now
- **BREAKING CHANGE**: make memoization default false on all storage mechanisms
- **BREAKING CHANGE**: the `onChange()` methods on storage mechanisms and messages has been renamed to `set()`
- **BREAKING CHANGE**: rename `InvalidValueMarker` to `invalid`